### PR TITLE
feat: add turnstile widget to login noreg

### DIFF
--- a/ui/ui/customer/login-noreg.tpl
+++ b/ui/ui/customer/login-noreg.tpl
@@ -52,6 +52,12 @@
                             </span>
                         </div>
                     </div>
+                    {if $_c['turnstile_client_enabled']=='1' && $_c['turnstile_site_key'] ne ''}
+                        <div class="form-group">
+                            <div class="cf-turnstile" data-sitekey="{$_c['turnstile_site_key']}" data-theme="auto" data-action="client_login"></div>
+                        </div>
+                        <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+                    {/if}
                     <div class="btn-group btn-group-justified mb15">
                         <div class="btn-group">
                             <button type="submit" class="btn btn-primary">{Lang::T('Login / Activate Voucher')}</button>
@@ -77,6 +83,12 @@
                             </span>
                         </div>
                     </div>
+                    {if $_c['turnstile_client_enabled']=='1' && $_c['turnstile_site_key'] ne ''}
+                        <div class="form-group">
+                            <div class="cf-turnstile" data-sitekey="{$_c['turnstile_site_key']}" data-theme="auto" data-action="client_login"></div>
+                        </div>
+                        <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+                    {/if}
                     <div class="btn-group btn-group-justified mb15">
                         <div class="btn-group">
                             <button type="submit" class="btn btn-primary">{Lang::T('Activate Voucher')}</button>


### PR DESCRIPTION
## Summary
- integrate Cloudflare Turnstile protection into voucher login forms

## Testing
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68a9e4c18108832aaa62cb8b7643cce8