### PR TITLE
Use POST with CSRF tokens for customer actions

### DIFF
--- a/system/controllers/customers.php
+++ b/system/controllers/customers.php
@@ -25,7 +25,7 @@ switch ($action) {
         if (!in_array($admin['user_type'], ['SuperAdmin', 'Admin'])) {
             _alert(Lang::T('You do not have permission to access this page'), 'danger', "dashboard");
         }
-        $csrf_token = _req('token');
+        $csrf_token = _post('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
@@ -166,7 +166,7 @@ switch ($action) {
         }
         $id_customer = $routes['2'];
         $plan_id = $routes['3'];
-        $csrf_token = _req('token');
+        $csrf_token = _post('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id_customer, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
@@ -241,7 +241,7 @@ switch ($action) {
         }
         $id_customer = $routes['2'];
         $plan_id = $routes['3'];
-        $csrf_token = _req('token');
+        $csrf_token = _post('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id_customer, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
@@ -273,7 +273,7 @@ switch ($action) {
         break;
     case 'sync':
         $id_customer = $routes['2'];
-        $csrf_token = _req('token');
+        $csrf_token = _post('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id_customer, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
@@ -309,7 +309,7 @@ switch ($action) {
             _alert(Lang::T('You do not have permission to access this page'), 'danger', "dashboard");
         }
         $id = $routes['2'];
-        $csrf_token = _req('token');
+        $csrf_token = _post('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
@@ -419,7 +419,7 @@ switch ($action) {
             _alert(Lang::T('You do not have permission to access this page'), 'danger', "dashboard");
         }
         $id = $routes['2'];
-        $csrf_token = _req('token');
+        $csrf_token = _post('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }

--- a/ui/ui/admin/customers/list.tpl
+++ b/ui/ui/admin/customers/list.tpl
@@ -17,10 +17,12 @@
             <div class="panel-heading">
                 {if in_array($_admin['user_type'],['SuperAdmin','Admin'])}
                 <div class="btn-group pull-right">
-                    <a class="btn btn-primary btn-xs" title="save"
-                        href="{Text::url('customers/csv&token=', $csrf_token)}"
-                        onclick="return ask(this, '{Lang::T("This will export to CSV")}?')"><span
-                            class="glyphicon glyphicon-download" aria-hidden="true"></span> CSV</a>
+                    <form method="post" action="{Text::url('customers/csv')}" style="display:inline;">
+                        <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                        <button class="btn btn-primary btn-xs" title="save"
+                            onclick="return ask(this, '{Lang::T("This will export to CSV")}?')"><span
+                                class="glyphicon glyphicon-download" aria-hidden="true"></span> CSV</button>
+                    </form>
                 </div>
                 {/if}
                 {Lang::T('Manage Contact')}
@@ -157,14 +159,16 @@
                                     <a href="{Text::url('customers/view/')}{$ds['id']}" id="{$ds['id']}"
                                         style="margin: 0px; color:black"
                                         class="btn btn-success btn-xs">&nbsp;&nbsp;{Lang::T('View')}&nbsp;&nbsp;</a>
-                                    <a href="{Text::url('customers/edit/', $ds['id'], '&token=', $csrf_token)}"
+                                    <a href="{Text::url('customers/edit/', $ds['id'])}"
                                         id="{$ds['id']}" style="margin: 0px; color:black"
                                         class="btn btn-info btn-xs">&nbsp;&nbsp;{Lang::T('Edit')}&nbsp;&nbsp;</a>
-                                    <a href="{Text::url('customers/sync/', $ds['id'], '&token=', $csrf_token)}"
-                                        id="{$ds['id']}" style="margin: 5px; color:black"
-                                        class="btn btn-success btn-xs">&nbsp;&nbsp;{Lang::T('Sync')}&nbsp;&nbsp;</a>
-                                    <a href="{Text::url('plan/recharge/', $ds['id'], '&token=', $csrf_token)}"
-                                        id="{$ds['id']}" style="margin: 0px;"
+                                    <form method="post" action="{Text::url('customers/sync/', $ds['id'])}"
+                                        style="display:inline;">
+                                        <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                                        <button type="submit" id="{$ds['id']}" style="margin: 5px; color:black"
+                                            class="btn btn-success btn-xs">&nbsp;&nbsp;{Lang::T('Sync')}&nbsp;&nbsp;</button>
+                                    </form>
+                                    <a href="{Text::url('plan/recharge/', $ds['id'])}" id="{$ds['id']}" style="margin: 0px;"
                                         class="btn btn-primary btn-xs">{Lang::T('Recharge')}</a>
                                 </td>
                             </tr>


### PR DESCRIPTION
## Summary
- Switch customer CSV export to POST and validate CSRF tokens server-side
- Remove CSRF tokens from query strings and send via POST for sync action

## Testing
- `php -l system/controllers/customers.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa94dd706c832a8aee5d04c82c190a