### PR TITLE
Use consistent csrf_token parameter

### DIFF
--- a/system/controllers/coupons.php
+++ b/system/controllers/coupons.php
@@ -249,7 +249,7 @@ switch ($action) {
 
         if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $couponId = $_GET['coupon_id'] ?? '';
-            $csrf_token =  $_GET['csrf_token'] ?? '';
+            $csrf_token = _req('csrf_token');
             $status = $_GET['status'] ?? '';
             if (empty($couponId) || empty($csrf_token) || !Csrf::check($csrf_token) || empty($status)) {
                 r2($_SERVER['HTTP_REFERER'], 'e', Lang::T("Invalid request"));

--- a/system/controllers/customers.php
+++ b/system/controllers/customers.php
@@ -166,7 +166,7 @@ switch ($action) {
         }
         $id_customer = $routes['2'];
         $plan_id = $routes['3'];
-        $csrf_token = _post('csrf_token');
+        $csrf_token = _req('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id_customer, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
@@ -241,7 +241,7 @@ switch ($action) {
         }
         $id_customer = $routes['2'];
         $plan_id = $routes['3'];
-        $csrf_token = _post('csrf_token');
+        $csrf_token = _req('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id_customer, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
@@ -273,7 +273,7 @@ switch ($action) {
         break;
     case 'sync':
         $id_customer = $routes['2'];
-        $csrf_token = _post('csrf_token');
+        $csrf_token = _req('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id_customer, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
@@ -309,7 +309,7 @@ switch ($action) {
             _alert(Lang::T('You do not have permission to access this page'), 'danger', "dashboard");
         }
         $id = $routes['2'];
-        $csrf_token = _post('csrf_token');
+        $csrf_token = _req('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
@@ -419,7 +419,7 @@ switch ($action) {
             _alert(Lang::T('You do not have permission to access this page'), 'danger', "dashboard");
         }
         $id = $routes['2'];
-        $csrf_token = _post('csrf_token');
+        $csrf_token = _req('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }

--- a/ui/ui/admin/coupons/list.tpl
+++ b/ui/ui/admin/coupons/list.tpl
@@ -188,7 +188,7 @@
                     </td> -->
                             <td colspan="10" style="text-align: center;">
                                 <div style="display: flex; justify-content: center; gap: 10px; flex-wrap: wrap;">
-                                    <a href="{Text::url('coupons/edit/', $coupon['id'], '&token=', $csrf_token)}"
+                                    <a href="{Text::url('coupons/edit/', $coupon['id'], '&csrf_token=', $csrf_token)}"
                                         id="{$coupon['id']}" class="btn btn-success btn-xs">{Lang::T('Edit')}</a>
                                     {if $coupon['status'] neq 'inactive'}
                                         <a href="javascript:void(0);"

--- a/ui/ui/admin/customers/view.tpl
+++ b/ui/ui/admin/customers/view.tpl
@@ -112,12 +112,12 @@
                 </ul>
                 <div class="row">
                     <div class="col-xs-4">
-                        <a href="{Text::url('customers/delete/', $d['id'], '&token=', $csrf_token)}" id="{$d['id']}"
+                        <a href="{Text::url('customers/delete/', $d['id'], '&csrf_token=', $csrf_token)}" id="{$d['id']}"
                             class="btn btn-danger btn-block btn-sm"
                             onclick="return ask(this, '{Lang::T('Delete')}?')"><span class="fa fa-trash"></span></a>
                     </div>
                     <div class="col-xs-8">
-                        <a href="{Text::url('customers/edit/', $d['id'], '&token=', $csrf_token)}"
+                        <a href="{Text::url('customers/edit/', $d['id'], '&csrf_token=', $csrf_token)}"
                             class="btn btn-warning btn-sm btn-block">{Lang::T('Edit')}</a>
                     </div>
                 </div>
@@ -242,12 +242,12 @@
                         </ul>
                         <div class="row">
                             <div class="col-xs-4">
-                                <a href="{Text::url('customers/deactivate/', $d['id'],'/',$package['plan_id'], '&token=', $csrf_token)}"
+                                <a href="{Text::url('customers/deactivate/', $d['id'],'/',$package['plan_id'], '&csrf_token=', $csrf_token)}"
                                     id="{$d['id']}" class="btn btn-danger btn-block btn-sm"
                                     onclick="return ask(this, '{Lang::T('This will deactivate Customer Plan, and make it expired')}')">{Lang::T('Deactivate')}</a>
                             </div>
                             <div class="col-xs-8">
-                                <a href="{Text::url('customers/recharge/', $d['id'], '/', $package['plan_id'], '&token=', $csrf_token)}"
+                                <a href="{Text::url('customers/recharge/', $d['id'], '/', $package['plan_id'], '&csrf_token=', $csrf_token)}"
                                     class="btn btn-success btn-sm btn-block">{Lang::T('Recharge')}</a>
                             </div>
                         </div>
@@ -264,18 +264,18 @@
         <a href="{Text::url('customers/list')}" class="btn btn-primary btn-sm btn-block">{Lang::T('Back')}</a>
     </div>
     <div class="col-xs-6 col-md-3">
-        <a href="{Text::url('customers/sync/', $d['id'], '&token=', $csrf_token)}"
+        <a href="{Text::url('customers/sync/', $d['id'], '&csrf_token=', $csrf_token)}"
             onclick="return ask(this, '{Lang::T('This will sync Customer to Mikrotik')}?')"
             class="btn btn-info btn-sm btn-block">{Lang::T('Sync')}</a>
     </div>
     <div class="col-xs-6 col-md-3">
-        <a href="{Text::url('message/send/', $d['id'], '&token=', $csrf_token)}"
+        <a href="{Text::url('message/send/', $d['id'], '&csrf_token=', $csrf_token)}"
             class="btn btn-success btn-sm btn-block">
             {Lang::T('Send Message')}
         </a>
     </div>
     <div class="col-xs-6 col-md-3">
-        <a href="{Text::url('customers/login/', $d['id'], '&token=', $csrf_token)}" target="_blank"
+        <a href="{Text::url('customers/login/', $d['id'], '&csrf_token=', $csrf_token)}" target="_blank"
             class="btn btn-warning btn-sm btn-block">
             {Lang::T('Login as Customer')}
         </a>


### PR DESCRIPTION
## Summary
- normalize controllers to read CSRF tokens via `_req('csrf_token')` when tokens are sent as query parameters
- standardize template links to pass `csrf_token` instead of `token` for customer and coupon actions

## Testing
- `php -l system/controllers/coupons.php`
- `php -l system/controllers/customers.php`
- `rg "\&token=" -n`


------
https://chatgpt.com/codex/tasks/task_e_68aa96693c64832a8f7d9874e3c4d95a