### PR TITLE
Add CSRF validation to registration flow

### DIFF
--- a/ui/ui/customer/register-otp.tpl
+++ b/ui/ui/customer/register-otp.tpl
@@ -11,6 +11,7 @@
         </div>
     </div>
     <form enctype="multipart/form-data" action="{Text::url('register/post')}" method="post">
+        <input type="hidden" name="csrf_token" value="{$csrf_token}">
         <div class="col-md-4">
             <div class="panel panel-primary">
                 <div class="panel-heading">1. {Lang::T('Register as Member')}</div>

--- a/ui/ui/customer/register-rotp.tpl
+++ b/ui/ui/customer/register-rotp.tpl
@@ -14,6 +14,7 @@
         </div>
     </div>
     <form action="{Text::url('register')}" method="post">
+        <input type="hidden" name="csrf_token" value="{$csrf_token}">
         <div class="col-md-4">
             <div class="panel panel-primary">
                 <div class="panel-heading">1. {Lang::T('Register as Member')}</div>

--- a/ui/ui/customer/register.tpl
+++ b/ui/ui/customer/register.tpl
@@ -11,6 +11,7 @@
         </div>
     </div>
     <form enctype="multipart/form-data" action="{Text::url('register/post')}" method="post">
+        <input type="hidden" name="csrf_token" value="{$csrf_token}">
         <div class="col-md-4">
             <div class="panel panel-primary">
                 <div class="panel-heading">1. {Lang::T('Register as Member')}</div>


### PR DESCRIPTION
## Summary
- Validate CSRF token on registration POST requests
- Render registration forms with hidden CSRF tokens

## Testing
- `php -l system/controllers/register.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa99533d60832aae81c4cbb9f2dd25