### PR TITLE
Refresh CSRF tokens after use

### DIFF
--- a/system/autoload/Csrf.php
+++ b/system/autoload/Csrf.php
@@ -28,10 +28,10 @@ class Csrf
                 foreach ($_SESSION['csrf_tokens'] as $index => $data) {
                     if (self::validateToken($token, $data['token'])) {
                         if (time() - $data['time'] > self::$tokenExpiration) {
-                            unset($_SESSION['csrf_tokens'][$index]);
+                            self::clearToken($token);
                             return false;
                         }
-                        unset($_SESSION['csrf_tokens'][$index]);
+                        self::clearToken($token);
                         return true;
                     }
                     if (time() - $data['time'] > self::$tokenExpiration) {

--- a/system/controllers/accounts.php
+++ b/system/controllers/accounts.php
@@ -29,6 +29,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('accounts/change-password'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         run_hook('customer_change_password'); #HOOK
         if ($password != '') {
             $d_pass = $user['password'];
@@ -83,6 +84,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('accounts/profile'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $fullname = _post('fullname');
         $address = _post('address');
         $email = _post('email');
@@ -179,6 +181,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('accounts/phone-update'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $phone = Lang::phoneFormat(_post('phone'));
         $username = $user['username'];
         $otpPath = $CACHE_PATH . '/sms/';
@@ -230,6 +233,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('accounts/phone-update'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $phone = Lang::phoneFormat(_post('phone'));
         $otp_code = _post('otp');
         $username = $user['username'];
@@ -298,6 +302,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('accounts/email-update'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $email = trim(_post('email'));
         $username = $user['username'];
         $otpPath = $CACHE_PATH . '/email/';
@@ -343,6 +348,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('accounts/email-update'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $email = trim(_post('email'));
         $otp_code = _post('otp');
         $username = $user['username'];

--- a/system/controllers/admin.php
+++ b/system/controllers/admin.php
@@ -28,6 +28,7 @@ switch ($do) {
         if (!Csrf::check($csrf_token)) {
             _alert(Lang::T('Invalid or Expired CSRF Token') . ".", 'danger', "admin");
         }
+        Csrf::generateAndStoreToken();
         run_hook('admin_login'); #HOOK
 
         // ==== Cloudflare Turnstile server-side validation ====

--- a/system/controllers/coupons.php
+++ b/system/controllers/coupons.php
@@ -35,6 +35,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2($_SERVER['HTTP_REFERER'], 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $code = Text::alphanumeric(_post('code', ''));
         $type = _post('type', '');
         $value = floatval(_post('value', ''));
@@ -145,6 +146,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2($_SERVER['HTTP_REFERER'], 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
 
         $code = Text::alphanumeric(_post('code', ''));
         $type = _post('type', '');
@@ -255,6 +257,7 @@ switch ($action) {
                 r2($_SERVER['HTTP_REFERER'], 'e', Lang::T("Invalid request"));
                 exit;
             }
+            Csrf::generateAndStoreToken();
             $coupon = ORM::for_table('tbl_coupons')->where('id', $couponId)->find_one();
             if (!$coupon) {
                 r2($_SERVER['HTTP_REFERER'], 'e', Lang::T("Coupon not found."));

--- a/system/controllers/customers.php
+++ b/system/controllers/customers.php
@@ -29,6 +29,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
 
         $cs = ORM::for_table('tbl_customers')
             ->select('tbl_customers.id', 'id')
@@ -170,6 +171,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id_customer, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $b = ORM::for_table('tbl_user_recharges')->where('customer_id', $id_customer)->where('plan_id', $plan_id)->find_one();
         if ($b) {
             $gateway = 'Recharge';
@@ -245,6 +247,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id_customer, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $b = ORM::for_table('tbl_user_recharges')->where('customer_id', $id_customer)->where('plan_id', $plan_id)->find_one();
         if ($b) {
             $p = ORM::for_table('tbl_plans')->where('id', $b['plan_id'])->find_one();
@@ -277,6 +280,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id_customer, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $bs = ORM::for_table('tbl_user_recharges')->where('customer_id', $id_customer)->where('status', 'on')->findMany();
         if ($bs) {
             $routers = [];
@@ -313,6 +317,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $customer = ORM::for_table('tbl_customers')->find_one($id);
         if ($customer) {
             $_SESSION['uid'] = $id;
@@ -463,6 +468,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/add'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $username = alphanumeric(_post('username'), ":+_.@-");
         $fullname = _post('fullname');
         $password = trim(_post('password'));
@@ -592,6 +598,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/edit/') . $id, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $username = alphanumeric(_post('username'), ":+_.@-");
         $fullname = _post('fullname');
         $account_type = _post('account_type');
@@ -863,6 +870,7 @@ switch ($action) {
             if (!Csrf::check($csrf_token)) {
                 r2(getUrl('customers'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
             }
+            Csrf::generateAndStoreToken();
             $d = $query->findMany();
             $h = false;
             set_time_limit(-1);

--- a/system/controllers/login.php
+++ b/system/controllers/login.php
@@ -29,6 +29,7 @@ switch ($do) {
             _msglog('e', Lang::T('Invalid or Expired CSRF Token'));
             r2(getUrl('login'));
         }
+        Csrf::generateAndStoreToken();
 
         // ==== Cloudflare Turnstile (Customer Login) ====
         $tsEnabled = (!empty($_c['turnstile_client_enabled']) && $_c['turnstile_client_enabled'] == '1');
@@ -110,6 +111,7 @@ switch ($do) {
                 _msglog('e', Lang::T('Invalid or Expired CSRF Token'));
                 r2(getUrl('login'));
             }
+            Csrf::generateAndStoreToken();
             $voucher = Text::alphanumeric(_post('voucher_only'), "-_.,");
             $tur = ORM::for_table('tbl_user_recharges')
                 ->where('username', $voucher)

--- a/system/controllers/register.php
+++ b/system/controllers/register.php
@@ -22,6 +22,7 @@ switch ($do) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('register'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $otp_code = _post('otp_code');
         $username = alphanumeric(_post('username'), "+_.@-");
         $email = _post('email');

--- a/system/controllers/settings.php
+++ b/system/controllers/settings.php
@@ -194,6 +194,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('settings/app'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $company = _post('CompanyName');
         $custom_tax_rate = filter_var(_post('custom_tax_rate'), FILTER_SANITIZE_SPECIAL_CHARS);
         if (preg_match('/[^0-9.]/', $custom_tax_rate)) {
@@ -258,6 +259,7 @@ switch ($action) {
             if (!Csrf::check($csrf_token)) {
                 r2(getUrl('settings/app'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
             }
+            Csrf::generateAndStoreToken();
 
             if ($login_page_type == 'custom' && (empty($login_Page_template) || empty($login_page_title) || empty($login_page_description))) {
                 r2(getUrl('settings/app'), 'e', 'Please fill all required fields');
@@ -397,6 +399,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('settings/localisation'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $tzone = _post('tzone');
         $date_format = _post('date_format');
         $country_code_phone = _post('country_code_phone');
@@ -695,6 +698,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('settings/users-add'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $username = _post('username');
         $fullname = _post('fullname');
         $password = _post('password');
@@ -766,6 +770,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('settings/users-edit/'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         $username = _post('username');
         $fullname = _post('fullname');
         $password = _post('password');
@@ -924,6 +929,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('settings/change-password'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         if ($password != '') {
             $d = ORM::for_table('tbl_users')->where('username', $admin['username'])->find_one();
             run_hook('change_password'); #HOOK
@@ -985,6 +991,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('settings/notifications'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         file_put_contents($UPLOAD_PATH . "/notifications.json", json_encode($_POST));
         r2(getUrl('settings/notifications'), 's', Lang::T('Settings Saved Successfully'));
         break;
@@ -1110,6 +1117,7 @@ switch ($action) {
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('settings/language'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         file_put_contents($lan_file, json_encode($_POST, JSON_PRETTY_PRINT));
         r2(getUrl('settings/language'), 's', Lang::T('Translation saved Successfully'));
         break;
@@ -1128,6 +1136,7 @@ switch ($action) {
             if (!Csrf::check($csrf_token)) {
                 r2(getUrl('settings/maintenance'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
             }
+            Csrf::generateAndStoreToken();
             $status = isset($_POST['maintenance_mode']) ? 1 : 0; // Checkbox returns 1 if checked, otherwise 0
             $force_logout = isset($_POST['maintenance_mode_logout']) ? 1 : 0; // Checkbox returns 1 if checked, otherwise 0
             $date = isset($_POST['maintenance_date']) ? $_POST['maintenance_date'] : null;
@@ -1173,6 +1182,7 @@ switch ($action) {
             if (!Csrf::check($csrf_token)) {
                 r2(getUrl('settings/miscellaneous'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
             }
+            Csrf::generateAndStoreToken();
             foreach ($_POST as $key => $value) {
                 $d = ORM::for_table('tbl_appconfig')->where('setting', $key)->find_one();
                 if ($d) {


### PR DESCRIPTION
## Summary
- Clear CSRF token upon successful validation to prevent reuse
- Regenerate CSRF tokens after successful operations across controllers

## Testing
- `php -l system/autoload/Csrf.php`
- `php -l system/controllers/login.php`
- `php -l system/controllers/coupons.php`
- `php -l system/controllers/customers.php`
- `php -l system/controllers/accounts.php`
- `php -l system/controllers/admin.php`
- `php -l system/controllers/settings.php`
- `php -l system/controllers/register.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa9b81d06c832aa4ffcfeb7761904a