### PR TITLE
Secure logout with CSRF-protected POST

### DIFF
--- a/system/boot.php
+++ b/system/boot.php
@@ -52,6 +52,10 @@ $ui->assign('CACHE_PATH', str_replace($root_path, '',  $CACHE_PATH));
 $ui->assign('PAGES_PATH', str_replace($root_path, '',  $PAGES_PATH));
 $ui->assign('_system_menu', 'dashboard');
 
+// CSRF token for logout form
+$csrf_token_logout = Csrf::generateAndStoreToken();
+$ui->assign('csrf_token_logout', $csrf_token_logout);
+
 function _msglog($type, $msg)
 {
     $_SESSION['ntype'] = $type;

--- a/system/controllers/logout.php
+++ b/system/controllers/logout.php
@@ -9,6 +9,10 @@ header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Expires: Tue, 01 Jan 2000 00:00:00 GMT");
 header("Pragma: no-cache");
 
+$csrf_token = _post('csrf_token');
+if (!Csrf::check($csrf_token)) {
+    _alert(Lang::T('Invalid or Expired CSRF Token'), 'danger', 'login');
+}
 run_hook('customer_logout'); #HOOK
 if (session_status() == PHP_SESSION_NONE) session_start();
 Admin::removeCookie();

--- a/ui/ui/admin/header.tpl
+++ b/ui/ui/admin/header.tpl
@@ -99,8 +99,11 @@
                                 </li>
                                 <li class="user-footer">
                                     <div class="pull-right">
-                                        <a href="{Text::url('logout')}" class="btn btn-default btn-flat"><i
-                                                class="ion ion-power"></i> {Lang::T('Logout')}</a>
+                                        <form method="post" action="{Text::url('logout')}" style="display:inline;">
+                                            <input type="hidden" name="csrf_token" value="{$csrf_token_logout}">
+                                            <button type="submit" class="btn btn-default btn-flat"><i
+                                                    class="ion ion-power"></i> {Lang::T('Logout')}</button>
+                                        </form>
                                     </div>
                                 </li>
                             </ul>

--- a/ui/ui/customer/header.tpl
+++ b/ui/ui/customer/header.tpl
@@ -110,8 +110,11 @@
                                 </li>
                                 <li class="user-footer">
                                     <div class="pull-right">
-                                        <a href="{Text::url('logout')}" class="btn btn-default btn-flat"><i
-                                                class="ion ion-power"></i> {Lang::T('Logout')}</a>
+                                        <form method="post" action="{Text::url('logout')}" style="display:inline;">
+                                            <input type="hidden" name="csrf_token" value="{$csrf_token_logout}">
+                                            <button type="submit" class="btn btn-default btn-flat"><i
+                                                    class="ion ion-power"></i> {Lang::T('Logout')}</button>
+                                        </form>
                                     </div>
                                 </li>
                             </ul>


### PR DESCRIPTION
## Summary
- replace logout links with POST forms carrying CSRF tokens
- validate CSRF token in logout controller
- provide global CSRF token for logout in bootstrap

## Testing
- `php -l system/boot.php`
- `php -l system/controllers/logout.php`


------
https://chatgpt.com/codex/tasks/task_e_68aaa4effdcc832a9826ae5aa7ee9245