### PR TITLE
Prevent duplicate phone numbers during registration

### DIFF
--- a/system/controllers/register.php
+++ b/system/controllers/register.php
@@ -90,6 +90,11 @@ switch ($do) {
         if ($d) {
             $msg .= Lang::T('Account already exists') . '<br>';
         }
+        // Check if phone number already exists
+        $d = ORM::for_table('tbl_customers')->where('phonenumber', $phone_number)->find_one();
+        if ($d) {
+            $msg .= Lang::T('Phone number already registered by another customer') . '<br>';
+        }
 
         if ($msg == '') {
             $d = ORM::for_table('tbl_customers')->create();
@@ -203,9 +208,9 @@ switch ($do) {
         if ($_c['sms_otp_registration'] == 'yes') {
             $phone_number = _post('phone_number');
             if (!empty($phone_number)) {
-                $d = ORM::for_table('tbl_customers')->where('username', $phone_number)->find_one();
+                $d = ORM::for_table('tbl_customers')->where('phonenumber', $phone_number)->find_one();
                 if ($d) {
-                    r2(getUrl('register'), 's', Lang::T('Account already exists'));
+                    r2(getUrl('register'), 'e', Lang::T('Phone number already registered by another customer'));
                 }
                 if (!file_exists($otpPath)) {
                     mkdir($otpPath);


### PR DESCRIPTION
## Summary
- block registration when phone number already exists
- check phone number uniqueness before sending OTP to avoid duplicate accounts

## Testing
- ✅ `php -l system/controllers/register.php`
- ⚠️ `composer test` (Command "test" is not defined.)
- ⚠️ `phpunit` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68aad654c098832aaf6002f1e2449fda