### PR TITLE
Use POST forms for admin actions

### DIFF
--- a/system/controllers/coupons.php
+++ b/system/controllers/coupons.php
@@ -120,6 +120,14 @@ switch ($action) {
         }
 
         $coupon_id = intval($routes['2']);
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            r2(getUrl('coupons'), 'e', Lang::T('Invalid request method'));
+        }
+        $csrf_token = _post('csrf_token');
+        if (!Csrf::check($csrf_token)) {
+            r2(getUrl('coupons'), 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
+        }
+        Csrf::generateAndStoreToken();
         if (empty($coupon_id)) {
             r2(getUrl('coupons'), 'e', Lang::T('Invalid Coupon ID'));
             exit;
@@ -249,10 +257,10 @@ switch ($action) {
             exit;
         }
 
-        if ($_SERVER['REQUEST_METHOD'] === 'GET') {
-            $couponId = $_GET['coupon_id'] ?? '';
-            $csrf_token = _req('csrf_token');
-            $status = $_GET['status'] ?? '';
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $couponId = _post('coupon_id', '');
+            $csrf_token = _post('csrf_token');
+            $status = _post('status', '');
             if (empty($couponId) || empty($csrf_token) || !Csrf::check($csrf_token) || empty($status)) {
                 r2($_SERVER['HTTP_REFERER'], 'e', Lang::T("Invalid request"));
                 exit;

--- a/system/controllers/customers.php
+++ b/system/controllers/customers.php
@@ -167,7 +167,10 @@ switch ($action) {
         }
         $id_customer = $routes['2'];
         $plan_id = $routes['3'];
-        $csrf_token = _req('csrf_token');
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            r2(getUrl('customers/view/') . $id_customer, 'e', Lang::T('Invalid request method'));
+        }
+        $csrf_token = _post('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id_customer, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
@@ -243,7 +246,10 @@ switch ($action) {
         }
         $id_customer = $routes['2'];
         $plan_id = $routes['3'];
-        $csrf_token = _req('csrf_token');
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            r2(getUrl('customers/view/') . $id_customer, 'e', Lang::T('Invalid request method'));
+        }
+        $csrf_token = _post('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id_customer, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
@@ -276,7 +282,10 @@ switch ($action) {
         break;
     case 'sync':
         $id_customer = $routes['2'];
-        $csrf_token = _req('csrf_token');
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            r2(getUrl('customers/view/') . $id_customer, 'e', Lang::T('Invalid request method'));
+        }
+        $csrf_token = _post('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id_customer, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
@@ -313,7 +322,10 @@ switch ($action) {
             _alert(Lang::T('You do not have permission to access this page'), 'danger', "dashboard");
         }
         $id = $routes['2'];
-        $csrf_token = _req('csrf_token');
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            r2(getUrl('customers/view/') . $id, 'e', Lang::T('Invalid request method'));
+        }
+        $csrf_token = _post('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
@@ -384,6 +396,14 @@ switch ($action) {
             _alert(Lang::T('You do not have permission to access this page'), 'danger', "dashboard");
         }
         $id = $routes['2'];
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            r2(getUrl('customers/view/') . $id, 'e', Lang::T('Invalid request method'));
+        }
+        $csrf_token = _post('csrf_token');
+        if (!Csrf::check($csrf_token)) {
+            r2(getUrl('customers/view/') . $id, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
+        }
+        Csrf::generateAndStoreToken();
         run_hook('edit_customer'); #HOOK
         $d = ORM::for_table('tbl_customers')->find_one($id);
         // Fetch the Customers Attributes values from the tbl_customers_fields table
@@ -412,7 +432,7 @@ switch ($action) {
             $ui->assign('statuses', ORM::for_table('tbl_customers')->getEnum("status"));
             $ui->assign('customFields', $customFields);
             $ui->assign('xheader', $leafletpickerHeader);
-            $ui->assign('csrf_token',  Csrf::generateAndStoreToken());
+            $ui->assign('csrf_token', Csrf::generateAndStoreToken());
             $ui->display('admin/customers/edit.tpl');
         } else {
             r2(getUrl('customers/list'), 'e', Lang::T('Account Not Found'));
@@ -424,10 +444,14 @@ switch ($action) {
             _alert(Lang::T('You do not have permission to access this page'), 'danger', "dashboard");
         }
         $id = $routes['2'];
-        $csrf_token = _req('csrf_token');
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            r2(getUrl('customers/view/') . $id, 'e', Lang::T('Invalid request method'));
+        }
+        $csrf_token = _post('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('customers/view/') . $id, 'e', Lang::T('Invalid or Expired CSRF Token') . ".");
         }
+        Csrf::generateAndStoreToken();
         run_hook('delete_customer'); #HOOK
         $c = ORM::for_table('tbl_customers')->find_one($id);
         if ($c) {

--- a/ui/ui/admin/coupons/list.tpl
+++ b/ui/ui/admin/coupons/list.tpl
@@ -188,20 +188,26 @@
                     </td> -->
                             <td colspan="10" style="text-align: center;">
                                 <div style="display: flex; justify-content: center; gap: 10px; flex-wrap: wrap;">
-                                    <a href="{Text::url('coupons/edit/', $coupon['id'], '&csrf_token=', $csrf_token)}"
-                                        id="{$coupon['id']}" class="btn btn-success btn-xs">{Lang::T('Edit')}</a>
+                                    <form method="post" action="{Text::url('coupons/edit/', $coupon['id'])}">
+                                        <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                                        <button type="submit" id="{$coupon['id']}" class="btn btn-success btn-xs">{Lang::T('Edit')}</button>
+                                    </form>
                                     {if $coupon['status'] neq 'inactive'}
-                                        <a href="javascript:void(0);"
-                                            onclick="confirmAction('{Text::url('coupons/status/&coupon_id=',$coupon['id'], '&status=inactive&csrf_token=', $csrf_token)}', '{Lang::T('Block')}')"
-                                            id="{$coupon['id']}" class="btn btn-danger btn-xs">
-                                            {Lang::T('Block')}
-                                        </a>
+                                        <form method="post" action="{Text::url('coupons/status')}">
+                                            <input type="hidden" name="coupon_id" value="{$coupon['id']}">
+                                            <input type="hidden" name="status" value="inactive">
+                                            <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                                            <button type="button" id="{$coupon['id']}" class="btn btn-danger btn-xs"
+                                                onclick="confirmAction(this.form, '{Lang::T('Block')}')">{Lang::T('Block')}</button>
+                                        </form>
                                     {else}
-                                        <a href="javascript:void(0);"
-                                            onclick="confirmAction('{Text::url('coupons/status/&coupon_id=', $coupon['id'], '&status=active&csrf_token=', $csrf_token)}', '{Lang::T('Unblock')}')"
-                                            id="{$coupon['id']}" class="btn btn-warning btn-xs">
-                                            {Lang::T('Unblock')}
-                                        </a>
+                                        <form method="post" action="{Text::url('coupons/status')}">
+                                            <input type="hidden" name="coupon_id" value="{$coupon['id']}">
+                                            <input type="hidden" name="status" value="active">
+                                            <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                                            <button type="button" id="{$coupon['id']}" class="btn btn-warning btn-xs"
+                                                onclick="confirmAction(this.form, '{Lang::T('Unblock')}')">{Lang::T('Unblock')}</button>
+                                        </form>
                                     {/if}
                                 </div>
                             </td>
@@ -330,7 +336,7 @@
 </script>
 {literal}
     <script>
-        function confirmAction(url, action) {
+        function confirmAction(form, action) {
             Swal.fire({
                 title: 'Are you sure?',
                 text: `Do you really want to ${action.toLowerCase()} this coupon?`,
@@ -342,7 +348,7 @@
                 cancelButtonText: 'No, cancel!'
             }).then((result) => {
                 if (result.isConfirmed) {
-                    window.location.href = url;
+                    form.submit();
                 }
             });
         }

--- a/ui/ui/admin/customers/view.tpl
+++ b/ui/ui/admin/customers/view.tpl
@@ -112,13 +112,17 @@
                 </ul>
                 <div class="row">
                     <div class="col-xs-4">
-                        <a href="{Text::url('customers/delete/', $d['id'], '&csrf_token=', $csrf_token)}" id="{$d['id']}"
-                            class="btn btn-danger btn-block btn-sm"
-                            onclick="return ask(this, '{Lang::T('Delete')}?')"><span class="fa fa-trash"></span></a>
+                        <form method="post" action="{Text::url('customers/delete/', $d['id'])}">
+                            <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                            <button type="submit" id="{$d['id']}" class="btn btn-danger btn-block btn-sm"
+                                onclick="return ask(this, '{Lang::T('Delete')}?')"><span class="fa fa-trash"></span></button>
+                        </form>
                     </div>
                     <div class="col-xs-8">
-                        <a href="{Text::url('customers/edit/', $d['id'], '&csrf_token=', $csrf_token)}"
-                            class="btn btn-warning btn-sm btn-block">{Lang::T('Edit')}</a>
+                        <form method="post" action="{Text::url('customers/edit/', $d['id'])}">
+                            <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                            <button type="submit" class="btn btn-warning btn-sm btn-block">{Lang::T('Edit')}</button>
+                        </form>
                     </div>
                 </div>
             </div>
@@ -242,13 +246,17 @@
                         </ul>
                         <div class="row">
                             <div class="col-xs-4">
-                                <a href="{Text::url('customers/deactivate/', $d['id'],'/',$package['plan_id'], '&csrf_token=', $csrf_token)}"
-                                    id="{$d['id']}" class="btn btn-danger btn-block btn-sm"
-                                    onclick="return ask(this, '{Lang::T('This will deactivate Customer Plan, and make it expired')}')">{Lang::T('Deactivate')}</a>
+                                <form method="post" action="{Text::url('customers/deactivate/', $d['id'],'/',$package['plan_id'])}">
+                                    <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                                    <button type="submit" id="{$d['id']}" class="btn btn-danger btn-block btn-sm"
+                                        onclick="return ask(this, '{Lang::T('This will deactivate Customer Plan, and make it expired')}')">{Lang::T('Deactivate')}</button>
+                                </form>
                             </div>
                             <div class="col-xs-8">
-                                <a href="{Text::url('customers/recharge/', $d['id'], '/', $package['plan_id'], '&csrf_token=', $csrf_token)}"
-                                    class="btn btn-success btn-sm btn-block">{Lang::T('Recharge')}</a>
+                                <form method="post" action="{Text::url('customers/recharge/', $d['id'], '/', $package['plan_id'])}">
+                                    <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                                    <button type="submit" class="btn btn-success btn-sm btn-block">{Lang::T('Recharge')}</button>
+                                </form>
                             </div>
                         </div>
                     </div>
@@ -264,21 +272,27 @@
         <a href="{Text::url('customers/list')}" class="btn btn-primary btn-sm btn-block">{Lang::T('Back')}</a>
     </div>
     <div class="col-xs-6 col-md-3">
-        <a href="{Text::url('customers/sync/', $d['id'], '&csrf_token=', $csrf_token)}"
-            onclick="return ask(this, '{Lang::T('This will sync Customer to Mikrotik')}?')"
-            class="btn btn-info btn-sm btn-block">{Lang::T('Sync')}</a>
+        <form method="post" action="{Text::url('customers/sync/', $d['id'])}">
+            <input type="hidden" name="csrf_token" value="{$csrf_token}">
+            <button type="submit" class="btn btn-info btn-sm btn-block"
+                onclick="return ask(this, '{Lang::T('This will sync Customer to Mikrotik')}?')">{Lang::T('Sync')}</button>
+        </form>
     </div>
     <div class="col-xs-6 col-md-3">
-        <a href="{Text::url('message/send/', $d['id'], '&csrf_token=', $csrf_token)}"
-            class="btn btn-success btn-sm btn-block">
-            {Lang::T('Send Message')}
-        </a>
+        <form method="post" action="{Text::url('message/send/', $d['id'])}">
+            <input type="hidden" name="csrf_token" value="{$csrf_token}">
+            <button type="submit" class="btn btn-success btn-sm btn-block">
+                {Lang::T('Send Message')}
+            </button>
+        </form>
     </div>
     <div class="col-xs-6 col-md-3">
-        <a href="{Text::url('customers/login/', $d['id'], '&csrf_token=', $csrf_token)}" target="_blank"
-            class="btn btn-warning btn-sm btn-block">
-            {Lang::T('Login as Customer')}
-        </a>
+        <form method="post" action="{Text::url('customers/login/', $d['id'])}" target="_blank">
+            <input type="hidden" name="csrf_token" value="{$csrf_token}">
+            <button type="submit" class="btn btn-warning btn-sm btn-block">
+                {Lang::T('Login as Customer')}
+            </button>
+        </form>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Replace customer and coupon action links with POST forms carrying CSRF tokens
- Require POST requests and CSRF token validation in customers and coupons controllers
- Refresh CSRF tokens after each action and support form submissions through SweetAlert

## Testing
- `php -l system/controllers/customers.php`
- `php -l system/controllers/coupons.php`


------
https://chatgpt.com/codex/tasks/task_e_68aada1dfc68832a9dd9c3788c67212c