### PR TITLE
Add CSRF protection to customer widgets

### DIFF
--- a/system/controllers/home.php
+++ b/system/controllers/home.php
@@ -17,6 +17,11 @@ if (isset($_GET['renewal'])) {
 }
 
 if (_post('send') == 'balance') {
+    $csrf_token = _post('csrf_token');
+    if (!Csrf::check($csrf_token)) {
+        r2(getUrl('home'), 'e', Lang::T('Invalid or Expired CSRF Token') . '.');
+    }
+    Csrf::generateAndStoreToken();
     if ($config['enable_balance'] == 'yes' && $config['allow_balance_transfer'] == 'yes') {
         if ($user['status'] != 'Active') {
             _alert(Lang::T('This account status') . ' : ' . Lang::T($user['status']), 'danger', "");
@@ -81,6 +86,11 @@ if (_post('send') == 'balance') {
         r2(getUrl('home'), 'd', Lang::T('Failed, balance is not available'));
     }
 } else if (_post('send') == 'plan') {
+    $csrf_token = _post('csrf_token');
+    if (!Csrf::check($csrf_token)) {
+        r2(getUrl('home'), 'e', Lang::T('Invalid or Expired CSRF Token') . '.');
+    }
+    Csrf::generateAndStoreToken();
     if ($user['status'] != 'Active') {
         _alert(Lang::T('This account status') . ' : ' . Lang::T($user['status']), 'danger', "");
     }
@@ -309,6 +319,9 @@ if (!empty($_SESSION['nux-mac']) && !empty($_SESSION['nux-ip'] && !empty($_SESSI
     }
 }
 
+
+$csrf_token = Csrf::generateAndStoreToken();
+$ui->assign('csrf_token', $csrf_token);
 
 $widgets = ORM::for_table('tbl_widgets')->where("enabled", 1)->where('user', 'Customer')->order_by_asc("orders")->findArray();
 $count = count($widgets);

--- a/ui/ui/widget/customers/balance_transfer.tpl
+++ b/ui/ui/widget/customers/balance_transfer.tpl
@@ -6,6 +6,7 @@
         </div>
         <div class="box-body p-0">
             <form method="post" onsubmit="return askConfirm()" role="form" action="{Text::url('home')}">
+                <input type="hidden" name="csrf_token" value="{$csrf_token}">
                 <div class="form-group">
                     <div class="col-sm-5">
                         <input type="text" id="username" name="username" class="form-control" required

--- a/ui/ui/widget/customers/recharge_a_friend.tpl
+++ b/ui/ui/widget/customers/recharge_a_friend.tpl
@@ -4,6 +4,7 @@
     </div>
     <div class="box-body p-0">
         <form method="post" role="form" action="{Text::url('home')}">
+            <input type="hidden" name="csrf_token" value="{$csrf_token}">
             <div class="form-group">
                 <div class="col-sm-10">
                     <input type="text" id="username" name="username" class="form-control" required

--- a/ui/ui/widget/customers/voucher_activation.tpl
+++ b/ui/ui/widget/customers/voucher_activation.tpl
@@ -6,6 +6,7 @@
         </div>
         <div class="box-body">
             <form method="post" role="form" class="form-horizontal" action="{Text::url('voucher/activation-post')}">
+                <input type="hidden" name="csrf_token" value="{$csrf_token}">
                 <div class="input-group">
                     <span class="input-group-btn">
                         <a class="btn btn-default"


### PR DESCRIPTION
## Summary
- add hidden CSRF token fields to customer widget forms
- validate CSRF tokens in balance transfer and plan sharing actions
- regenerate and assign new tokens after processing requests

## Testing
- `php -l system/controllers/home.php`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68aade23a37c832aa2f0baf4c68f943b