### PR TITLE
Add CSRF protection to plan management forms

### DIFF
--- a/ui/ui/admin/plan/active.tpl
+++ b/ui/ui/admin/plan/active.tpl
@@ -20,6 +20,7 @@
                 {Lang::T('Active Customers')}
             </div>
             <form id="site-search" method="post" action="{Text::url('')}plan/list/">
+                <input type="hidden" name="csrf_token" value="{$csrf_token}">
                 <div class="panel-body">
                     <div class="row row-no-gutters" style="padding: 5px">
                         <div class="col-lg-2">

--- a/ui/ui/admin/plan/deposit.tpl
+++ b/ui/ui/admin/plan/deposit.tpl
@@ -7,6 +7,7 @@
             <div class="panel-body">
                 <form class="form-horizontal" method="post" role="form" action="{Text::url('')}plan/deposit-post">
                     <input type="hidden" name="stoken" value="{App::getToken()}">
+                    <input type="hidden" name="csrf_token" value="{$csrf_token}">
                     <div class="form-group">
                         <label class="col-md-3 control-label">{Lang::T('Select Account')}</label>
                         <div class="col-md-9">

--- a/ui/ui/admin/plan/edit.tpl
+++ b/ui/ui/admin/plan/edit.tpl
@@ -9,6 +9,7 @@
             <div class="panel-body">
                 <form class="form-horizontal" method="post" role="form" action="{Text::url('')}plan/edit-post">
                     <input type="hidden" name="id" value="{$d['id']}">
+                    <input type="hidden" name="csrf_token" value="{$csrf_token}">
                     <div class="form-group">
                         <label class="col-md-2 control-label">{Lang::T('Select Account')}</label>
                         <div class="col-md-6">

--- a/ui/ui/admin/plan/invoice.tpl
+++ b/ui/ui/admin/plan/invoice.tpl
@@ -9,6 +9,7 @@
                     <center><img src="{$app_url}/{$logo}?"></center>
                 {/if}
                 <form class="form-horizontal" method="post" action="{Text::url('')}plan/print" target="_blank">
+                    <input type="hidden" name="csrf_token" value="{$csrf_token}">
                     <pre id="content"
                     style="border: 0px; ;text-align: center; background-color: transparent; background-image: url('{$app_url}/system/uploads/paid.png');background-repeat:no-repeat;background-position: center"></pre>
                     <textarea class="hidden" id="formcontent" name="content">{$invoice}</textarea>

--- a/ui/ui/admin/plan/recharge-confirm.tpl
+++ b/ui/ui/admin/plan/recharge-confirm.tpl
@@ -6,6 +6,7 @@
             <div class="panel-heading">{Lang::T('Confirm')}</div>
             <div class="panel-body">
                 <form class="form-horizontal" method="post" role="form" action="{Text::url('')}plan/recharge-post">
+                    <input type="hidden" name="csrf_token" value="{$csrf_token}">
                     <center><b>{Lang::T('Customer')}</b></center>
                     <ul class="list-group list-group-unbordered">
                         <li class="list-group-item">

--- a/ui/ui/admin/plan/recharge.tpl
+++ b/ui/ui/admin/plan/recharge.tpl
@@ -6,6 +6,7 @@
             <div class="panel-heading">{Lang::T('Recharge Account')}</div>
             <div class="panel-body">
                 <form class="form-horizontal" method="post" role="form" action="{Text::url('')}plan/recharge-confirm">
+                    <input type="hidden" name="csrf_token" value="{$csrf_token}">
                     <div class="form-group">
                         <label class="col-md-2 control-label">{Lang::T('Select Account')}</label>
                         <div class="col-md-6">

--- a/ui/ui/admin/plan/refill.tpl
+++ b/ui/ui/admin/plan/refill.tpl
@@ -6,6 +6,7 @@
             <div class="panel-heading">{Lang::T('Refill Account')}</div>
             <div class="panel-body">
                 <form class="form-horizontal" method="post" role="form" action="{Text::url('')}plan/refill-post">
+                    <input type="hidden" name="csrf_token" value="{$csrf_token}">
                     <div class="form-group">
                         <label class="col-md-2 control-label">{Lang::T('Select Account')}</label>
                         <div class="col-md-6">


### PR DESCRIPTION
## Summary
- Guard plan controller actions with CSRF token generation and validation.
- Inject hidden `csrf_token` fields in plan management templates.

## Testing
- `php -l system/controllers/plan.php`


------
https://chatgpt.com/codex/tasks/task_e_68aae28f7fb8832a870482cda203d6c3