### PR TITLE
Add CSRF protection to pool management forms

### DIFF
--- a/system/controllers/pool.php
+++ b/system/controllers/pool.php
@@ -39,6 +39,7 @@ switch ($action) {
         $r = ORM::for_table('tbl_routers')->find_many();
         $ui->assign('r', $r);
         run_hook('view_add_pool'); #HOOK
+        $ui->assign('csrf_token', Csrf::generateAndStoreToken());
         $ui->display('admin/pool/add.tpl');
         break;
 
@@ -48,6 +49,7 @@ switch ($action) {
         if ($d) {
             $ui->assign('d', $d);
             run_hook('view_edit_pool'); #HOOK
+            $ui->assign('csrf_token', Csrf::generateAndStoreToken());
             $ui->display('admin/pool/edit.tpl');
         } else {
             r2(getUrl('pool/list'), 'e', Lang::T('Account Not Found'));
@@ -80,6 +82,11 @@ switch ($action) {
         r2(getUrl('pool/list'), 's', $log);
         break;
     case 'add-post':
+        $csrf_token = _post('csrf_token');
+        if (!Csrf::check($csrf_token)) {
+            r2(getUrl('pool/add'), 'e', Lang::T('Invalid or Expired CSRF Token') . '.');
+        }
+        Csrf::generateAndStoreToken();
         $name = _post('name');
         $ip_address = _post('ip_address');
         $local_ip = _post('local_ip');
@@ -115,6 +122,12 @@ switch ($action) {
 
 
     case 'edit-post':
+        $csrf_token = _post('csrf_token');
+        $id = _post('id');
+        if (!Csrf::check($csrf_token)) {
+            r2(getUrl('pool/edit/') . $id, 'e', Lang::T('Invalid or Expired CSRF Token') . '.');
+        }
+        Csrf::generateAndStoreToken();
         $local_ip = _post('local_ip');
         $ip_address = _post('ip_address');
         $routers = _post('routers');
@@ -125,7 +138,6 @@ switch ($action) {
             $msg .= Lang::T('All field is required') . '<br>';
         }
 
-        $id = _post('id');
         $d = ORM::for_table('tbl_pool')->find_one($id);
         $old = ORM::for_table('tbl_pool')->find_one($id);
         if (!$d) {
@@ -167,6 +179,7 @@ switch ($action) {
         $r = ORM::for_table('tbl_routers')->find_many();
         $ui->assign('r', $r);
         run_hook('view_add_port'); #HOOK
+        $ui->assign('csrf_token', Csrf::generateAndStoreToken());
         $ui->display('admin/port/add.tpl');
         break;
 
@@ -176,6 +189,7 @@ switch ($action) {
         if ($d) {
             $ui->assign('d', $d);
             run_hook('view_edit_port'); #HOOK
+            $ui->assign('csrf_token', Csrf::generateAndStoreToken());
             $ui->display('admin/port/edit.tpl');
         } else {
             r2(getUrl('pool/port'), 'e', Lang::T('Account Not Found'));
@@ -205,6 +219,11 @@ switch ($action) {
         r2(getUrl('pool/list'), 's', $log);
         break;
     case 'add-port-post':
+        $csrf_token = _post('csrf_token');
+        if (!Csrf::check($csrf_token)) {
+            r2(getUrl('pool/add-port'), 'e', Lang::T('Invalid or Expired CSRF Token') . '.');
+        }
+        Csrf::generateAndStoreToken();
         $name = _post('name');
         $port_range = _post('port_range');
         $public_ip = _post('public_ip');
@@ -237,12 +256,17 @@ switch ($action) {
 
 
     case 'edit-port-post':
+        $csrf_token = _post('csrf_token');
+        $id = _post('id');
+        if (!Csrf::check($csrf_token)) {
+            r2(getUrl('pool/edit-port/') . $id, 'e', Lang::T('Invalid or Expired CSRF Token') . '.');
+        }
+        Csrf::generateAndStoreToken();
         $name = _post('name');
         $public_ip = _post('public_ip');
         $range_port = _post('range_port');
         $routers = _post('routers');
         run_hook('edit_port'); #HOOK
-        $msg = '';
         $msg = '';
         if (Validator::Length($name, 30, 2) == false) {
             $msg .= 'Name should be between 3 to 30 characters' . '<br>';
@@ -251,7 +275,6 @@ switch ($action) {
             $msg .= Lang::T('All field is required') . '<br>';
         }
 
-        $id = _post('id');
         $d = ORM::for_table('tbl_port_pool')->find_one($id);
         $old = ORM::for_table('tbl_port_pool')->find_one($id);
         if (!$d) {

--- a/ui/ui/admin/pool/add.tpl
+++ b/ui/ui/admin/pool/add.tpl
@@ -7,10 +7,11 @@
 						<div class="panel-body">
 
                 <form class="form-horizontal" method="post" role="form" action="{Text::url('')}pool/add-post" >
+                    <input type="hidden" name="csrf_token" value="{$csrf_token}">
                     <div class="form-group">
-						<label class="col-md-2 control-label">{Lang::T('Name Pool')}</label>
-						<div class="col-md-6">
-							<input type="text" class="form-control" id="name" name="name">
+                                                <label class="col-md-2 control-label">{Lang::T('Name Pool')}</label>
+                                                <div class="col-md-6">
+                                                        <input type="text" class="form-control" id="name" name="name">
 						</div>
                     </div>
                     <div class="form-group">

--- a/ui/ui/admin/pool/edit.tpl
+++ b/ui/ui/admin/pool/edit.tpl
@@ -6,12 +6,13 @@
 			<div class="panel-heading">{Lang::T('Edit Pool')}</div>
 			<div class="panel-body">
 
-				<form class="form-horizontal" method="post" role="form" action="{Text::url('')}pool/edit-post">
-					<input type="hidden" name="id" value="{$d['id']}">
-					<div class="form-group">
-						<label class="col-md-2 control-label">{Lang::T('Name Pool')}</label>
-						<div class="col-md-6">
-							<input type="text" class="form-control" id="name" name="name" value="{$d['pool_name']}"
+                                <form class="form-horizontal" method="post" role="form" action="{Text::url('')}pool/edit-post">
+                                        <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                                        <input type="hidden" name="id" value="{$d['id']}">
+                                        <div class="form-group">
+                                                <label class="col-md-2 control-label">{Lang::T('Name Pool')}</label>
+                                                <div class="col-md-6">
+                                                        <input type="text" class="form-control" id="name" name="name" value="{$d['pool_name']}"
 								readonly>
 						</div>
 					</div>

--- a/ui/ui/admin/port/add.tpl
+++ b/ui/ui/admin/port/add.tpl
@@ -5,11 +5,12 @@
 		<div class="panel panel-primary panel-hovered panel-stacked mb30">
 			<div class="panel-heading">{Lang::T('Add Port Pool')}</div>
 			<div class="panel-body">
-				<form class="form-horizontal" method="post" role="form" action="{Text::url('')}pool/add-port-post">
-					<div class="form-group">
-						<label class="col-md-2 control-label">{Lang::T('Port Name')}</label>
-						<div class="col-md-6">
-							<input type="text" class="form-control" id="name" name="name" placeholder="Vpn Tunnel">
+                                <form class="form-horizontal" method="post" role="form" action="{Text::url('')}pool/add-port-post">
+                                        <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                                        <div class="form-group">
+                                                <label class="col-md-2 control-label">{Lang::T('Port Name')}</label>
+                                                <div class="col-md-6">
+                                                        <input type="text" class="form-control" id="name" name="name" placeholder="Vpn Tunnel">
 						</div>
 					</div>
 					<div class="form-group">

--- a/ui/ui/admin/port/edit.tpl
+++ b/ui/ui/admin/port/edit.tpl
@@ -6,12 +6,13 @@
 			<div class="panel-heading">{Lang::T('Edit Port')}</div>
 			<div class="panel-body">
 
-				<form class="form-horizontal" method="post" role="form" action="{Text::url('')}pool/edit-port-post">
-					<input type="hidden" name="id" value="{$d['id']}">
-					<div class="form-group">
-						<label class="col-md-2 control-label">{Lang::T('Port Name')}</label>
-						<div class="col-md-6">
-							<input type="text" class="form-control" id="name" name="name" value="{$d['port_name']}">
+                                <form class="form-horizontal" method="post" role="form" action="{Text::url('')}pool/edit-port-post">
+                                        <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                                        <input type="hidden" name="id" value="{$d['id']}">
+                                        <div class="form-group">
+                                                <label class="col-md-2 control-label">{Lang::T('Port Name')}</label>
+                                                <div class="col-md-6">
+                                                        <input type="text" class="form-control" id="name" name="name" value="{$d['port_name']}">
 						</div>
 					</div>
 					<div class="form-group">


### PR DESCRIPTION
## Summary
- generate CSRF tokens for pool and port add/edit forms
- validate CSRF tokens on pool and port POST handlers
- embed hidden CSRF fields in pool and port templates

## Testing
- `php -l system/controllers/pool.php`


------
https://chatgpt.com/codex/tasks/task_e_68aae46c3540832aa3ca33bd5d79c0f6