### PR TITLE
Add CSRF protection to bandwidth management

### DIFF
--- a/system/controllers/bandwidth.php
+++ b/system/controllers/bandwidth.php
@@ -19,6 +19,12 @@ if (!in_array($admin['user_type'], ['SuperAdmin', 'Admin'])) {
 switch ($action) {
     case 'list':
         run_hook('view_list_bandwidth'); #HOOK
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $csrf_token = _post('csrf_token');
+            if (!Csrf::check($csrf_token)) {
+                r2($_SERVER['HTTP_REFERER'], 'e', Lang::T('Invalid or Expired CSRF Token') . '.');
+            }
+        }
         $name = _post('name');
         if ($name != '') {
             $query = ORM::for_table('tbl_bandwidth')->where_like('name_bw', '%' . $name . '%')->order_by_desc('id');
@@ -29,6 +35,8 @@ switch ($action) {
         }
 
         $ui->assign('d', $d);
+        $csrf_token = Csrf::generateAndStoreToken();
+        $ui->assign('csrf_token', $csrf_token);
         $ui->display('admin/bandwidth/list.tpl');
         break;
 
@@ -37,6 +45,8 @@ switch ($action) {
             _alert(Lang::T('You do not have permission to access this page'), 'danger', "dashboard");
         }
         run_hook('view_add_bandwidth'); #HOOK
+        $csrf_token = Csrf::generateAndStoreToken();
+        $ui->assign('csrf_token', $csrf_token);
         $ui->display('admin/bandwidth/add.tpl');
         break;
 
@@ -50,6 +60,8 @@ switch ($action) {
         if ($d) {
             $ui->assign('burst', explode(" ", $d['burst']));
             $ui->assign('d', $d);
+            $csrf_token = Csrf::generateAndStoreToken();
+            $ui->assign('csrf_token', $csrf_token);
             $ui->display('admin/bandwidth/edit.tpl');
         } else {
             r2(getUrl('bandwidth/list'), 'e', Lang::T('Account Not Found'));
@@ -73,6 +85,11 @@ switch ($action) {
         if (!in_array($admin['user_type'], ['SuperAdmin', 'Admin'])) {
             _alert(Lang::T('You do not have permission to access this page'), 'danger', "dashboard");
         }
+        $csrf_token = _post('csrf_token');
+        if (!Csrf::check($csrf_token)) {
+            r2($_SERVER['HTTP_REFERER'], 'e', Lang::T('Invalid or Expired CSRF Token') . '.');
+        }
+        Csrf::generateAndStoreToken();
         $name = _post('name');
         $rate_down = _post('rate_down');
         $rate_down_unit = _post('rate_down_unit');
@@ -132,6 +149,11 @@ switch ($action) {
         if (!in_array($admin['user_type'], ['SuperAdmin', 'Admin'])) {
             _alert(Lang::T('You do not have permission to access this page'), 'danger', "dashboard");
         }
+        $csrf_token = _post('csrf_token');
+        if (!Csrf::check($csrf_token)) {
+            r2($_SERVER['HTTP_REFERER'], 'e', Lang::T('Invalid or Expired CSRF Token') . '.');
+        }
+        Csrf::generateAndStoreToken();
         $name = _post('name');
         $rate_down = _post('rate_down');
         $rate_down_unit = _post('rate_down_unit');

--- a/ui/ui/admin/bandwidth/add.tpl
+++ b/ui/ui/admin/bandwidth/add.tpl
@@ -5,8 +5,9 @@
 		<div class="panel panel-primary panel-hovered panel-stacked mb30">
 			<div class="panel-heading">{Lang::T('Add New Bandwidth')}</div>
 			<div class="panel-body">
-				<form class="form-horizontal" method="post" role="form" action="{Text::url('bandwidth/add-post')}">
-					<div class="form-group">
+                                <form class="form-horizontal" method="post" role="form" action="{Text::url('bandwidth/add-post')}">
+                                        <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                                        <div class="form-group">
 						<label class="col-md-3 control-label">{Lang::T('Bandwidth Name')}</label>
 						<div class="col-md-9">
 							<input type="text" class="form-control" id="name" name="name">

--- a/ui/ui/admin/bandwidth/edit.tpl
+++ b/ui/ui/admin/bandwidth/edit.tpl
@@ -6,8 +6,9 @@
 			<div class="panel-heading">{Lang::T('Edit Bandwidth')}</div>
 			<div class="panel-body">
 
-				<form class="form-horizontal" method="post" role="form" action="{Text::url('bandwidth/edit-post')}">
-					<input type="hidden" name="id" value="{$d['id']}">
+                                <form class="form-horizontal" method="post" role="form" action="{Text::url('bandwidth/edit-post')}">
+                                        <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                                        <input type="hidden" name="id" value="{$d['id']}">
 					<div class="form-group">
 						<label class="col-md-3 control-label">{Lang::T('Bandwidth Name')}</label>
 						<div class="col-md-9">

--- a/ui/ui/admin/bandwidth/list.tpl
+++ b/ui/ui/admin/bandwidth/list.tpl
@@ -7,8 +7,9 @@
 			<div class="panel-body">
 				<div class="md-whiteframe-z1 mb20 text-center" style="padding: 15px">
 					<div class="col-md-8">
-						<form id="site-search" method="post" action="{Text::url('bandwidth/list/')}">
-							<div class="input-group">
+                                                <form id="site-search" method="post" action="{Text::url('bandwidth/list/')}">
+                                                        <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                                                        <div class="input-group">
 								<div class="input-group-addon">
 									<span class="fa fa-search"></span>
 								</div>


### PR DESCRIPTION
## Summary
- validate CSRF tokens on bandwidth list, add, and edit actions
- regenerate CSRF tokens and expose them to bandwidth templates
- embed hidden CSRF token fields in bandwidth add, edit, and search forms

## Testing
- `php -l system/controllers/bandwidth.php`


------
https://chatgpt.com/codex/tasks/task_e_68aae586e2d4832aa268c2ade1d31177