### PR TITLE
Add CSRF validation to RADIUS NAS management

### DIFF
--- a/system/controllers/radius.php
+++ b/system/controllers/radius.php
@@ -22,9 +22,15 @@ switch ($action) {
         $ui->assign('_system_menu', 'radius');
         $ui->assign('_title', "Network Access Server");
         $ui->assign('routers', ORM::for_table('tbl_routers')->find_many());
+        $ui->assign('csrf_token', Csrf::generateAndStoreToken());
         $ui->display('admin/radius/nas-add.tpl');
         break;
     case 'nas-add-post':
+        $csrf_token = _post('csrf_token');
+        if (!Csrf::check($csrf_token)) {
+            r2(getUrl('radius/nas-add'), 'e', Lang::T('Invalid or Expired CSRF Token') . '.');
+        }
+        Csrf::generateAndStoreToken();
         $shortname = _post('shortname');
         $nasname = _post('nasname');
         $secret = _post('secret');
@@ -78,6 +84,7 @@ switch ($action) {
         if ($d) {
             $ui->assign('routers', ORM::for_table('tbl_routers')->find_many());
             $ui->assign('d', $d);
+            $ui->assign('csrf_token', Csrf::generateAndStoreToken());
             $ui->display('admin/radius/nas-edit.tpl');
         } else {
             r2(getUrl('radius/list'), 'e', Lang::T('Account Not Found'));
@@ -86,6 +93,11 @@ switch ($action) {
         break;
     case 'nas-edit-post':
         $id  = $routes['2'];
+        $csrf_token = _post('csrf_token');
+        if (!Csrf::check($csrf_token)) {
+            r2(getUrl('radius/nas-edit/') . $id, 'e', Lang::T('Invalid or Expired CSRF Token') . '.');
+        }
+        Csrf::generateAndStoreToken();
         $shortname = _post('shortname');
         $nasname = _post('nasname');
         $secret = _post('secret');
@@ -124,6 +136,11 @@ switch ($action) {
         }
         break;
     case 'nas-delete':
+        $csrf_token = _get('csrf_token');
+        if (!Csrf::check($csrf_token)) {
+            r2(getUrl('radius/nas-list'), 'e', Lang::T('Invalid or Expired CSRF Token') . '.');
+        }
+        Csrf::generateAndStoreToken();
         $id  = $routes['2'];
         $d = ORM::for_table('nas', 'radius')->find_one($id);
         if ($d) {
@@ -134,6 +151,12 @@ switch ($action) {
     default:
         $ui->assign('_system_menu', 'radius');
         $ui->assign('_title', "Network Access Server");
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $csrf_token = _post('csrf_token');
+            if (!Csrf::check($csrf_token)) {
+                r2($_SERVER['HTTP_REFERER'], 'e', Lang::T('Invalid or Expired CSRF Token') . '.');
+            }
+        }
         $name = _post('name');
         if (empty($name)) {
             $query = ORM::for_table('nas', 'radius');
@@ -147,5 +170,6 @@ switch ($action) {
         }
         $ui->assign('name', $name);
         $ui->assign('nas', $nas);
+        $ui->assign('csrf_token', Csrf::generateAndStoreToken());
         $ui->display('admin/radius/nas.tpl');
 }

--- a/ui/ui/admin/radius/nas-add.tpl
+++ b/ui/ui/admin/radius/nas-add.tpl
@@ -8,6 +8,7 @@
             <div class="panel-body">
 
                 <form class="form-horizontal" method="post" role="form" action="{Text::url('')}radius/nas-add-post">
+                    <input type="hidden" name="csrf_token" value="{$csrf_token}">
                     <div class="form-group">
                         <label class="col-md-2 control-label">{Lang::T('Router Name')}</label>
                         <div class="col-md-6">

--- a/ui/ui/admin/radius/nas-edit.tpl
+++ b/ui/ui/admin/radius/nas-edit.tpl
@@ -9,6 +9,7 @@
 
                 <form class="form-horizontal" method="post" role="form"
                     action="{Text::url('')}radius/nas-edit-post/{$d['id']}">
+                    <input type="hidden" name="csrf_token" value="{$csrf_token}">
                     <div class="form-group">
                         <label class="col-md-2 control-label">{Lang::T('Router Name')}</label>
                         <div class="col-md-6">

--- a/ui/ui/admin/radius/nas.tpl
+++ b/ui/ui/admin/radius/nas.tpl
@@ -10,6 +10,7 @@
                 <div class="md-whiteframe-z1 mb20 text-center" style="padding: 15px">
                     <div class="col-md-8">
                         <form id="site-search" method="post" action="{Text::url('')}radius/nas-list">
+                            <input type="hidden" name="csrf_token" value="{$csrf_token}">
                             <div class="input-group">
                                 <div class="input-group-addon">
                                     <span class="fa fa-search"></span>
@@ -55,7 +56,7 @@
                                     <td align="center">
                                         <a href="{Text::url('')}radius/nas-edit/{$ds['id']}"
                                             class="btn btn-info btn-xs">{Lang::T('Edit')}</a>
-                                        <a href="{Text::url('')}radius/nas-delete/{$ds['id']}" id="{$ds['id']}"
+                                        <a href="{Text::url('')}radius/nas-delete/{$ds['id']}?csrf_token={$csrf_token}" id="{$ds['id']}"
                                             onclick="return ask(this, '{Lang::T('Delete')}?')"
                                             class="btn btn-danger btn-xs"><i class="glyphicon glyphicon-trash"></i></a>
                                     </td>


### PR DESCRIPTION
## Summary
- enforce CSRF checks on RADIUS NAS add, edit, and delete actions
- embed CSRF tokens in RADIUS NAS management forms

## Testing
- `php -l system/controllers/radius.php`

------
https://chatgpt.com/codex/tasks/task_e_68aae6c6c7bc832a8321c3284362c39d