### PR TITLE
Add CSRF protection to order forms

### DIFF
--- a/ui/ui/customer/orderBalance.tpl
+++ b/ui/ui/customer/orderBalance.tpl
@@ -39,6 +39,7 @@
                         <div class="col col-md-4">
                             <form action="{Text::url('order/gateway/0/0')}" method="post">
                                 <input type="hidden" name="custom" value="1">
+                                <input type="hidden" name="csrf_token" value="{$csrf_token}">
                                 <div class="box box-solid box-default">
                                     <div class="box-header text-bold">{Lang::T('Custom Balance')}</div>
                                     <div class="table-responsive">

--- a/ui/ui/customer/selectGateway.tpl
+++ b/ui/ui/customer/selectGateway.tpl
@@ -74,6 +74,7 @@
                 {if $discount == '' && $plan['type'] neq 'Balance' && $custom == '' && $_c['enable_coupons'] == 'yes'}
                     <!-- Coupon Code Form -->
                     <form action="{Text::url('order/gateway/')}{$route2}/{$route3}" method="post">
+                        <input type="hidden" name="csrf_token" value="{$csrf_token}">
                         <div class="form-group row">
                             <label class="col-md-4 control-label">{Lang::T('Coupon Code')}</label>
                             <div class="col-md-8">
@@ -144,6 +145,7 @@
 
                 <!-- Payment Gateway Form -->
                 <form method="post" action="{Text::url('order/buy/')}{$route2}/{$route3}">
+                    <input type="hidden" name="csrf_token" value="{$csrf_token}">
                     <input type="hidden" name="coupon" value="{$discount}">
                     {if $custom == '1' && $amount neq ''}
                         <input type="hidden" name="custom" value="1">

--- a/ui/ui/customer/sendPlan.tpl
+++ b/ui/ui/customer/sendPlan.tpl
@@ -46,6 +46,7 @@
             </div>
             <div class="box-footer">
                 <form method="post" onsubmit="return askConfirm()" role="form">
+                    <input type="hidden" name="csrf_token" value="{$csrf_token}">
                     <div class="form-group">
                         <div class="col-sm-9">
                             <input type="text" id="username" name="username" class="form-control" required


### PR DESCRIPTION
## Summary
- generate CSRF tokens for balance and order workflows
- validate CSRF tokens when submitting send, gateway, and buy requests
- update order templates to include hidden `csrf_token` fields

## Testing
- `php -l system/controllers/order.php`


------
https://chatgpt.com/codex/tasks/task_e_68aae7f793b0832a93c793ac4c922e11