### PR TITLE
Improve CSRF token check to handle missing tokens

### DIFF
--- a/system/autoload/Csrf.php
+++ b/system/autoload/Csrf.php
@@ -24,7 +24,7 @@ class Csrf
     {
         global $config, $isApi;
         if ($config['csrf_enabled'] == 'yes' && !$isApi) {
-            if (!empty($_SESSION['csrf_tokens']) && isset($token)) {
+            if (!empty($_SESSION['csrf_tokens']) && !empty($token)) {
                 foreach ($_SESSION['csrf_tokens'] as $index => $data) {
                     if (self::validateToken($token, $data['token'])) {
                         if (time() - $data['time'] > self::$tokenExpiration) {
@@ -38,8 +38,13 @@ class Csrf
                         unset($_SESSION['csrf_tokens'][$index]);
                     }
                 }
+                return false;
+            } else {
+                if (empty($token)) {
+                    error_log('CSRF token not provided.');
+                }
+                return false;
             }
-            return false;
         }
         return true;
     }


### PR DESCRIPTION
## Summary
- Require non-empty CSRF token during validation
- Log missing CSRF token for easier debugging

## Testing
- `php -l system/autoload/Csrf.php`


------
https://chatgpt.com/codex/tasks/task_e_68aaeb54a5f0832aab6b8e19e1e25ca5