### PR TITLE
Add CSRF token refresh and AJAX updater

### DIFF
--- a/init.php
+++ b/init.php
@@ -331,6 +331,9 @@ function sendWhatsapp($phone, $txt)
 function r2($to, $ntype = 'e', $msg = '')
 {
     global $isApi;
+    // Generate a fresh CSRF token for subsequent requests
+    // so that each POST action will require a new token.
+    Csrf::generateAndStoreToken();
     if ($isApi) {
         showResult(
             ($ntype == 's') ? true : false,

--- a/system/boot.php
+++ b/system/boot.php
@@ -55,6 +55,7 @@ $ui->assign('_system_menu', 'dashboard');
 // CSRF token for logout form
 $csrf_token_logout = Csrf::generateAndStoreToken();
 $ui->assign('csrf_token_logout', $csrf_token_logout);
+$ui->assign('csrf_token', Csrf::generateAndStoreToken());
 
 function _msglog($type, $msg)
 {

--- a/system/controllers/csrf-refresh.php
+++ b/system/controllers/csrf-refresh.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Endpoint to refresh CSRF token via AJAX
+ */
+_admin();
+header('Content-Type: application/json');
+$token = Csrf::generateAndStoreToken();
+echo json_encode(['csrf_token' => $token]);

--- a/ui/ui/admin/footer.tpl
+++ b/ui/ui/admin/footer.tpl
@@ -14,6 +14,7 @@
 <script src="{$app_url}/ui/ui/scripts/pace.min.js"></script>
 <script src="{$app_url}/ui/ui/summernote/summernote.min.js"></script>
 <script src="{$app_url}/ui/ui/scripts/custom.js?2025.2.5"></script>
+<script src="{$app_url}/ui/ui/scripts/csrf-refresh.js"></script>
 
 <script>
     document.getElementById('openSearch').addEventListener('click', function () {

--- a/ui/ui/scripts/csrf-refresh.js
+++ b/ui/ui/scripts/csrf-refresh.js
@@ -1,0 +1,18 @@
+(function ($) {
+    function refreshCsrfToken() {
+        $.getJSON(appUrl + '/?_route=csrf-refresh', function (data) {
+            if (data && data.csrf_token) {
+                $('input[name="csrf_token"]').val(data.csrf_token);
+            }
+        });
+    }
+
+    $(document).ajaxComplete(function () {
+        refreshCsrfToken();
+    });
+
+    // Initial refresh in case the page was loaded via AJAX
+    refreshCsrfToken();
+
+    window.refreshCsrfToken = refreshCsrfToken;
+})(jQuery);


### PR DESCRIPTION
## Summary
- Rotate CSRF token on each redirect to prevent reuse
- Serve `/csrf-refresh` endpoint for JS clients to fetch a new token
- Automatically update hidden CSRF fields after AJAX requests

## Testing
- `php -l init.php`
- `php -l system/boot.php`
- `php -l system/controllers/csrf-refresh.php`


------
https://chatgpt.com/codex/tasks/task_e_68aaeed6eae4832a92f69a04c3606097