### PR TITLE
Clear CSRF token after successful validation

### DIFF
--- a/system/autoload/Csrf.php
+++ b/system/autoload/Csrf.php
@@ -31,7 +31,8 @@ class Csrf
                             self::clearToken($token);
                             return false;
                         }
-                        // Token is valid and within the allowed time window; keep it
+                        // Token is valid and within the allowed time window; clear and return
+                        self::clearToken($token);
                         return true;
                     }
                     if (time() - $data['time'] > self::$tokenExpiration) {


### PR DESCRIPTION
## Summary
- Clear CSRF token once it passes validation to prevent reuse

## Testing
- `php -l system/autoload/Csrf.php`
- `composer test` *(fails: Command "test" is not defined)*
- `php -r 'session_start(); $config=["csrf_enabled"=>"yes"]; $isApi=false; require "system/autoload/Csrf.php"; $t=Csrf::generateAndStoreToken(); var_dump(Csrf::check($t)); var_dump(Csrf::check($t));'`


------
https://chatgpt.com/codex/tasks/task_e_68ab00047eac832aa2d3a26ab3f72a3e