### PR TITLE
Allow customers to refresh CSRF token

### DIFF
--- a/system/controllers/csrf-refresh.php
+++ b/system/controllers/csrf-refresh.php
@@ -2,7 +2,10 @@
 /**
  * Endpoint to refresh CSRF token via AJAX
  */
-_admin();
+if (!_admin(false) && !_auth(false)) {
+    http_response_code(403);
+    exit;
+}
 header('Content-Type: application/json');
 $token = Csrf::generateAndStoreToken();
 echo json_encode(['csrf_token' => $token]);


### PR DESCRIPTION
## Summary
- permit authenticated customers to fetch refreshed CSRF token via AJAX

## Testing
- `php -l system/controllers/csrf-refresh.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab04f7c87c832ab8235ccc703e7d75