### PR TITLE
Use consistent hash_equals order in CSRF validation

### DIFF
--- a/system/autoload/Csrf.php
+++ b/system/autoload/Csrf.php
@@ -17,7 +17,7 @@ class Csrf
 
     public static function validateToken($token, $storedToken)
     {
-        return hash_equals($token, $storedToken);
+        return hash_equals($storedToken, $token);
     }
 
     public static function check($token)


### PR DESCRIPTION
## Summary
- Ensure CSRF tokens are compared using stored token first in `hash_equals`.

## Testing
- `php -r 'session_start(); require "system/autoload/Csrf.php"; $config=["csrf_enabled"=>"yes"]; $isApi=false; $token=Csrf::generateAndStoreToken(); var_dump(Csrf::check($token));'`
- `php -r 'session_start(); require "system/autoload/Csrf.php"; $config=["csrf_enabled"=>"yes"]; $isApi=false; $token=Csrf::generateAndStoreToken(); var_dump(Csrf::check("invalid"));'`
- `php -r 'session_start(); require "system/autoload/Csrf.php"; $config=["csrf_enabled"=>"yes"]; $isApi=false; $token=Csrf::generateAndStoreToken(); $_SESSION["csrf_tokens"][0]["time"]=time()-1900; var_dump(Csrf::check($token));'`


------
https://chatgpt.com/codex/tasks/task_e_68ab068aae20832a889608d009b33a4e