### PR TITLE
Add error handling for CSRF token refresh

### DIFF
--- a/ui/ui/scripts/csrf-refresh.js
+++ b/ui/ui/scripts/csrf-refresh.js
@@ -1,10 +1,14 @@
 (function ($) {
     function refreshCsrfToken() {
-        $.getJSON(appUrl + '/?_route=csrf-refresh', function (data) {
-            if (data && data.csrf_token) {
-                $('input[name="csrf_token"]').val(data.csrf_token);
-            }
-        });
+        $.getJSON(appUrl + '/?_route=csrf-refresh')
+            .done(function (data) {
+                if (data && typeof data === 'object' && data.csrf_token) {
+                    $('input[name="csrf_token"]').val(data.csrf_token);
+                }
+            })
+            .fail(function () {
+                console.warn('CSRF refresh gagal');
+            });
     }
 
     $(document).ajaxComplete(function () {


### PR DESCRIPTION
## Summary
- add `fail` handler to CSRF token refresh script
- ensure CSRF token only updates on JSON responses

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ab074e241c832a809efd9c2f08174a