### PR TITLE
feat: isolate logout CSRF token

### DIFF
--- a/system/controllers/logout.php
+++ b/system/controllers/logout.php
@@ -9,8 +9,8 @@ header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Expires: Tue, 01 Jan 2000 00:00:00 GMT");
 header("Pragma: no-cache");
 
-$csrf_token = _post('csrf_token');
-if (!Csrf::check($csrf_token)) {
+$csrf_token_logout = _post('csrf_token_logout');
+if (!Csrf::check($csrf_token_logout)) {
     _alert(Lang::T('Invalid or Expired CSRF Token'), 'danger', 'login');
 }
 run_hook('customer_logout'); #HOOK

--- a/ui/ui/admin/header.tpl
+++ b/ui/ui/admin/header.tpl
@@ -100,7 +100,7 @@
                                 <li class="user-footer">
                                     <div class="pull-right">
                                         <form method="post" action="{Text::url('logout')}" style="display:inline;">
-                                            <input type="hidden" name="csrf_token" value="{$csrf_token_logout}">
+                                            <input type="hidden" name="csrf_token_logout" value="{$csrf_token_logout}">
                                             <button type="submit" class="btn btn-default btn-flat"><i
                                                     class="ion ion-power"></i> {Lang::T('Logout')}</button>
                                         </form>

--- a/ui/ui/customer/header.tpl
+++ b/ui/ui/customer/header.tpl
@@ -111,7 +111,7 @@
                                 <li class="user-footer">
                                     <div class="pull-right">
                                         <form method="post" action="{Text::url('logout')}" style="display:inline;">
-                                            <input type="hidden" name="csrf_token" value="{$csrf_token_logout}">
+                                            <input type="hidden" name="csrf_token_logout" value="{$csrf_token_logout}">
                                             <button type="submit" class="btn btn-default btn-flat"><i
                                                     class="ion ion-power"></i> {Lang::T('Logout')}</button>
                                         </form>

--- a/ui/ui/scripts/csrf-refresh.js
+++ b/ui/ui/scripts/csrf-refresh.js
@@ -3,7 +3,8 @@
         $.getJSON(appUrl + '/?_route=csrf-refresh')
             .done(function (data) {
                 if (data && typeof data === 'object' && data.csrf_token) {
-                    $('input[name="csrf_token"]').val(data.csrf_token);
+                    // Update general CSRF tokens but leave logout token untouched
+                    $('input[name="csrf_token"]').not('[name="csrf_token_logout"]').val(data.csrf_token);
                 }
             })
             .fail(function () {


### PR DESCRIPTION
## Summary
- use a dedicated CSRF token for logout
- update logout controller and templates to use the new token
- avoid refreshing logout token via csrf-refresh.js

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `npm test` *(fails: missing package.json)*
- `php -l system/controllers/logout.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab0b2db348832aa81503963bfd972b