### PR TITLE
Skip self-triggered CSRF refresh and add periodic renewal

### DIFF
--- a/ui/ui/scripts/csrf-refresh.js
+++ b/ui/ui/scripts/csrf-refresh.js
@@ -12,9 +12,14 @@
             });
     }
 
-    $(document).ajaxComplete(function () {
-        refreshCsrfToken();
+    $(document).ajaxComplete(function (_e, _xhr, settings) {
+        if (!settings.url.includes('csrf-refresh')) {
+            refreshCsrfToken();
+        }
     });
+
+    // Refresh tokens periodically (every 10 minutes)
+    setInterval(refreshCsrfToken, 10 * 60 * 1000);
 
     // Initial refresh in case the page was loaded via AJAX
     refreshCsrfToken();


### PR DESCRIPTION
## Summary
- prevent infinite csrf refresh loop by ignoring refresh requests in ajaxComplete handler
- periodically refresh csrf tokens every 10 minutes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0c4dfebc832ab24f948eeac05cd1