### PR TITLE
Limit stored CSRF tokens to recent entries

### DIFF
--- a/system/autoload/Csrf.php
+++ b/system/autoload/Csrf.php
@@ -57,6 +57,8 @@ class Csrf
             $_SESSION['csrf_tokens'] = [];
         }
         $_SESSION['csrf_tokens'][] = ['token' => $token, 'time' => time()];
+        // Keep only the most recent 20 tokens to prevent session growth
+        $_SESSION['csrf_tokens'] = array_slice($_SESSION['csrf_tokens'], -20);
         return $token;
     }
 


### PR DESCRIPTION
## Summary
- trim stored CSRF tokens to the last 20 entries to prevent session growth

## Testing
- `php -l system/autoload/Csrf.php`
- `php -r 'session_start(); require "system/autoload/Csrf.php"; $config=["csrf_enabled"=>"yes"]; $isApi=false; for($i=0;$i<50;$i++){ $token = Csrf::generateAndStoreToken(); } echo count($_SESSION["csrf_tokens"])."\n"; $valid = Csrf::check($token); echo ($valid ? "VALID" : "INVALID")."\n"; echo count($_SESSION["csrf_tokens"])."\n";'`


------
https://chatgpt.com/codex/tasks/task_e_68ab0d2dc48c832aa7258bee666c3b3c