### PR TITLE
Limit stored CSRF tokens

### DIFF
--- a/system/autoload/Csrf.php
+++ b/system/autoload/Csrf.php
@@ -9,6 +9,7 @@
 class Csrf
 {
     private static $tokenExpiration = 1800; // 30 minutes
+    private static $maxTokens = 20; // limit stored CSRF tokens
 
     public static function generateToken($length = 16)
     {
@@ -57,8 +58,8 @@ class Csrf
             $_SESSION['csrf_tokens'] = [];
         }
         $_SESSION['csrf_tokens'][] = ['token' => $token, 'time' => time()];
-        // Keep only the most recent 20 tokens to prevent session growth
-        $_SESSION['csrf_tokens'] = array_slice($_SESSION['csrf_tokens'], -20);
+        // Keep only the most recent tokens to prevent session growth
+        $_SESSION['csrf_tokens'] = array_slice($_SESSION['csrf_tokens'], -self::$maxTokens);
         return $token;
     }
 


### PR DESCRIPTION
## Summary
- Cap the number of stored CSRF tokens using a class property
- Trim session tokens after generation to prevent unbounded growth

## Testing
- `php -l system/autoload/Csrf.php`
- `php -r 'session_start(); require "system/autoload/Csrf.php"; for($i=0;$i<100;$i++){ Csrf::generateAndStoreToken(); } echo count($_SESSION["csrf_tokens"]);'`


------
https://chatgpt.com/codex/tasks/task_e_68ab1f0f05b8832abb33668f6b364ed6