### PR TITLE
Use POST with CSRF token for NAS delete

### DIFF
--- a/system/controllers/radius.php
+++ b/system/controllers/radius.php
@@ -136,7 +136,10 @@ switch ($action) {
         }
         break;
     case 'nas-delete':
-        $csrf_token = _get('csrf_token');
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            r2(getUrl('radius/nas-list'), 'e', Lang::T('Invalid Request'));
+        }
+        $csrf_token = _post('csrf_token');
         if (!Csrf::check($csrf_token)) {
             r2(getUrl('radius/nas-list'), 'e', Lang::T('Invalid or Expired CSRF Token') . '.');
         }
@@ -145,9 +148,11 @@ switch ($action) {
         $d = ORM::for_table('nas', 'radius')->find_one($id);
         if ($d) {
             $d->delete();
+            r2(getUrl('radius/nas-list'), 's', Lang::T('NAS Deleted'));
         } else {
             r2(getUrl('radius/nas-list'), 'e', 'NAS Not found');
         }
+        break;
     default:
         $ui->assign('_system_menu', 'radius');
         $ui->assign('_title', "Network Access Server");

--- a/ui/ui/admin/radius/nas.tpl
+++ b/ui/ui/admin/radius/nas.tpl
@@ -56,9 +56,10 @@
                                     <td align="center">
                                         <a href="{Text::url('')}radius/nas-edit/{$ds['id']}"
                                             class="btn btn-info btn-xs">{Lang::T('Edit')}</a>
-                                        <a href="{Text::url('')}radius/nas-delete/{$ds['id']}?csrf_token={$csrf_token}" id="{$ds['id']}"
-                                            onclick="return ask(this, '{Lang::T('Delete')}?')"
-                                            class="btn btn-danger btn-xs"><i class="glyphicon glyphicon-trash"></i></a>
+                                        <form method="post" action="{Text::url('')}radius/nas-delete/{$ds['id']}" style="display:inline;">
+                                            <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                                            <button type="submit" onclick="return ask(this, '{Lang::T('Delete')}?')" class="btn btn-danger btn-xs"><i class="glyphicon glyphicon-trash"></i></button>
+                                        </form>
                                     </td>
                                     <td align="center">{$ds['id']}</td>
                                 </tr>


### PR DESCRIPTION
## Summary
- Switch NAS delete link to a POST form with CSRF token
- Validate POST and token in radius controller before deleting NAS

## Testing
- `php -l system/controllers/radius.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab21ca358c832aaed12e7fec70a060