### PR TITLE
Inject CSRF token in jQuery Ajax requests

### DIFF
--- a/ui/ui/scripts/csrf-refresh.js
+++ b/ui/ui/scripts/csrf-refresh.js
@@ -1,4 +1,13 @@
 (function ($) {
+    $.ajaxSetup({
+        beforeSend: function(xhr, settings){
+            const token = $('input[name="csrf_token"]').first().val();
+            if (token && settings.type !== 'GET'){
+                settings.data = (settings.data ? settings.data + '&' : '') + 'csrf_token=' + encodeURIComponent(token);
+            }
+        }
+    });
+
     function refreshCsrfToken() {
         $.getJSON(appUrl + '/?_route=csrf-refresh')
             .done(function (data) {


### PR DESCRIPTION
## Summary
- Globally configure jQuery Ajax requests to append CSRF tokens for non-GET requests

## Testing
- `node --check ui/ui/scripts/csrf-refresh.js`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab22b3deb4832ab93026fc5960b17d