### PR TITLE
Log CSRF failures in logout without exposing token validity

### DIFF
--- a/system/controllers/logout.php
+++ b/system/controllers/logout.php
@@ -10,13 +10,16 @@ header("Expires: Tue, 01 Jan 2000 00:00:00 GMT");
 header("Pragma: no-cache");
 
 $csrf_token_logout = _post('csrf_token_logout');
-$token_valid       = Csrf::check($csrf_token_logout);
 
-if (!$token_valid) {
+if (!Csrf::check($csrf_token_logout)) {
     error_log('Invalid CSRF token during logout from IP ' . ($_SERVER['REMOTE_ADDR'] ?? ''));
 }
+
 run_hook('customer_logout'); #HOOK
-if (session_status() == PHP_SESSION_NONE) session_start();
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 Admin::removeCookie();
 User::removeCookie();
 session_destroy();


### PR DESCRIPTION
## Summary
- Log invalid CSRF tokens on logout without exposing token validity to users
- Always remove cookies, destroy session, and redirect regardless of CSRF check

## Testing
- `php -l system/controllers/logout.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab23f0ad54832a9d173cc3b9bb7b92