### PR TITLE
Gate CSRF refresh script

### DIFF
--- a/ui/ui/admin/footer.tpl
+++ b/ui/ui/admin/footer.tpl
@@ -14,7 +14,9 @@
 <script src="{$app_url}/ui/ui/scripts/pace.min.js"></script>
 <script src="{$app_url}/ui/ui/summernote/summernote.min.js"></script>
 <script src="{$app_url}/ui/ui/scripts/custom.js?2025.2.5"></script>
-<script src="{$app_url}/ui/ui/scripts/csrf-refresh.js"></script>
+{if $_c['csrf_enabled']=='yes'}
+    <script src="{$app_url}/ui/ui/scripts/csrf-refresh.js"></script>
+{/if}
 
 <script>
     document.getElementById('openSearch').addEventListener('click', function () {

--- a/ui/ui/customer/footer.tpl
+++ b/ui/ui/customer/footer.tpl
@@ -48,7 +48,9 @@
 
 <script src="{$app_url}/ui/ui/scripts/plugins/select2.min.js"></script>
 <script src="{$app_url}/ui/ui/scripts/custom.js?2025.2.5"></script>
-<script src="{$app_url}/ui/ui/scripts/csrf-refresh.js"></script>
+{if $_c['csrf_enabled']=='yes'}
+    <script src="{$app_url}/ui/ui/scripts/csrf-refresh.js"></script>
+{/if}
 
 {if isset($xfooter)}
     {$xfooter}

--- a/ui/ui/scripts/csrf-refresh.js
+++ b/ui/ui/scripts/csrf-refresh.js
@@ -1,4 +1,8 @@
 (function ($) {
+    if (typeof window.csrfEnabled !== 'undefined' && !window.csrfEnabled) {
+        return;
+    }
+
     $.ajaxSetup({
         beforeSend: function(xhr, settings){
             const token = $('input[name="csrf_token"]').first().val();


### PR DESCRIPTION
## Summary
- load `csrf-refresh.js` only when CSRF protection is enabled
- prevent CSRF AJAX helpers from running when a global `csrfEnabled` flag is false

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `composer test` *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_68ac069019f4832aaadaeba39d16252c