### PR TITLE
Ensure CSRF token included for FormData and JSON requests

### DIFF
--- a/ui/ui/scripts/csrf-refresh.js
+++ b/ui/ui/scripts/csrf-refresh.js
@@ -4,10 +4,19 @@
     }
 
     $.ajaxSetup({
-        beforeSend: function(xhr, settings){
+        beforeSend: function (xhr, settings) {
             const token = $('input[name="csrf_token"]').first().val();
-            if (token && settings.type !== 'GET'){
-                settings.data = (settings.data ? settings.data + '&' : '') + 'csrf_token=' + encodeURIComponent(token);
+            if (token && settings.type !== 'GET') {
+                if (settings.data instanceof FormData) {
+                    settings.data.append('csrf_token', token);
+                } else if (typeof settings.data === 'string' || !settings.data) {
+                    settings.data = (settings.data ? settings.data + '&' : '') +
+                                    'csrf_token=' + encodeURIComponent(token);
+                }
+
+                if (settings.contentType && settings.contentType.indexOf('application/json') === 0) {
+                    xhr.setRequestHeader('X-CSRF-Token', token);
+                }
             }
         }
     });


### PR DESCRIPTION
## Summary
- Append CSRF token to FormData uploads and data strings in ajax setup
- Optionally send CSRF token via `X-CSRF-Token` header for JSON requests

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `node csrf_formdata_test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ac11b6bc80832a8f2f9458019c4059