### PR TITLE
Improve CSRF token lifecycle and refresh interval

### DIFF
--- a/ui/ui/scripts/csrf-refresh.js
+++ b/ui/ui/scripts/csrf-refresh.js
@@ -40,8 +40,8 @@
         }
     });
 
-    // Refresh tokens periodically (every 10 minutes)
-    setInterval(refreshCsrfToken, 10 * 60 * 1000);
+    // Refresh tokens periodically (every 20 minutes)
+    setInterval(refreshCsrfToken, 20 * 60 * 1000);
 
     // Initial refresh in case the page was loaded via AJAX
     refreshCsrfToken();


### PR DESCRIPTION
## Summary
- increase stored CSRF token limit and implement pruning so valid tokens persist
- extend token lifetime and adjust refresh interval to 20 minutes

## Testing
- `php -l system/autoload/Csrf.php`
- `node --check ui/ui/scripts/csrf-refresh.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac19be62ec832ab3c26f04ee022d04