### PR TITLE
feat: check duplicate phone numbers during registration

### DIFF
--- a/system/controllers/register.php
+++ b/system/controllers/register.php
@@ -85,6 +85,12 @@ switch ($do) {
             $msg .= Lang::T('Account already exists') . '<br>';
         }
 
+        // Check if phone number already exists
+        $d = ORM::for_table('tbl_customers')->where('phonenumber', $phone_number)->find_one();
+        if ($d) {
+            $msg .= Lang::T('Phone number already exists') . '<br>';
+        }
+
         if ($msg == '') {
             $d = ORM::for_table('tbl_customers')->create();
             $d->username = alphanumeric($username, "+_.@-");
@@ -198,6 +204,10 @@ switch ($do) {
                 $d = ORM::for_table('tbl_customers')->where('username', $phone_number)->find_one();
                 if ($d) {
                     r2(getUrl('register'), 's', Lang::T('Account already exists'));
+                }
+                $d = ORM::for_table('tbl_customers')->where('phonenumber', $phone_number)->find_one();
+                if ($d) {
+                    r2(getUrl('register'), 's', Lang::T('Phone number already exists'));
                 }
                 if (!file_exists($otpPath)) {
                     mkdir($otpPath);


### PR DESCRIPTION
## Summary
- prevent account creation with already registered phone numbers
- block OTP sending to phone numbers already in use

## Testing
- `php -l system/controllers/register.php`


------
https://chatgpt.com/codex/tasks/task_e_68acbed4fac8832a8d8e7b5044555127