### PR TITLE
Validate customer phone uniqueness during add and edit

### DIFF
--- a/system/controllers/customers.php
+++ b/system/controllers/customers.php
@@ -500,6 +500,9 @@ switch ($action) {
         if ($d) {
             $msg .= Lang::T('Account already axist') . '<br>';
         }
+        if (ORM::for_table('tbl_customers')->where('phonenumber', Lang::phoneFormat($phonenumber))->find_one()) {
+            $msg .= Lang::T('Phone number already exists') . '<br>';
+        }
         if ($msg == '') {
             $d = ORM::for_table('tbl_customers')->create();
             $d->username = $username;
@@ -628,6 +631,12 @@ switch ($action) {
 
         if (!$c) {
             $msg .= Lang::T('Data Not Found') . '<br>';
+        }
+
+        if ($c && $c['phonenumber'] != $phonenumber) {
+            if (ORM::for_table('tbl_customers')->where('phonenumber', $phonenumber)->find_one()) {
+                $msg .= Lang::T('Phone number already registered by another customer') . '<br>';
+            }
         }
 
         //lets find user Customers Attributes using id


### PR DESCRIPTION
## Summary
- ensure adding a customer fails when the phone number already exists
- block editing a customer to a phone number used by another account

## Testing
- `php -l system/controllers/customers.php`


------
https://chatgpt.com/codex/tasks/task_e_68acbff39384832aa3b7317d7a00ea52