### PR TITLE
Add configurable OTP wait and expiry settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ The problem with windows is hard to set cronjob, better Linux
 
 [Installation instructions](https://github.com/hotspotbilling/phpnuxbill/wiki)
 
+## Configuration
+
+OTP timing can be tuned through two settings available in Admin → Settings → Miscellaneous:
+
+- `otp_wait` – seconds before a new OTP can be requested.
+- `otp_expiry` – seconds before an OTP becomes invalid.
+
 ## Freeradius
 
 Support [Freeradius with Database](https://github.com/hotspotbilling/phpnuxbill/wiki/FreeRadius)

--- a/init.php
+++ b/init.php
@@ -113,6 +113,9 @@ foreach ($result as $value) {
     $config[$value['setting']] = $value['value'];
 }
 
+if (empty($config['otp_wait']))  $config['otp_wait']  = 600;
+if (empty($config['otp_expiry'])) $config['otp_expiry'] = 1200;
+
 if(empty($config['dashboard_Admin'])){
     $config['dashboard_Admin'] = "12.7,5.12";
 }

--- a/install/phpnuxbill.sql
+++ b/install/phpnuxbill.sql
@@ -405,7 +405,7 @@ COMMIT;
 
 INSERT INTO
     `tbl_appconfig` (`id`, `setting`, `value`)
-VALUES (1, 'CompanyName', 'PHPNuxBill'), (2, 'currency_code', 'Rp.'), (3, 'language', 'english'), (4, 'show-logo', '1'), (5, 'nstyle', 'blue'), (6, 'timezone', 'Asia/Jakarta'), (7, 'dec_point', ','), (8, 'thousands_sep', '.'), (9, 'rtl', '0'), (10, 'address', ''), (11, 'phone', ''), (12, 'date_format', 'd M Y'), (13, 'note', 'Thank you...');
+VALUES (1, 'CompanyName', 'PHPNuxBill'), (2, 'currency_code', 'Rp.'), (3, 'language', 'english'), (4, 'show-logo', '1'), (5, 'nstyle', 'blue'), (6, 'timezone', 'Asia/Jakarta'), (7, 'dec_point', ','), (8, 'thousands_sep', '.'), (9, 'rtl', '0'), (10, 'address', ''), (11, 'phone', ''), (12, 'date_format', 'd M Y'), (13, 'note', 'Thank you...'), (14, 'otp_wait', '600'), (15, 'otp_expiry', '1200');
 
 
 INSERT INTO

--- a/system/controllers/accounts.php
+++ b/system/controllers/accounts.php
@@ -204,8 +204,8 @@ switch ($action) {
         $phoneFile = $otpPath . sha1($username . $db_pass) . "_phone.txt";
 
         // expired 10 minutes
-        if (file_exists($otpFile) && time() - filemtime($otpFile) < 600) {
-            r2(getUrl('accounts/phone-update'), 'e', Lang::T('Please wait ') . (600 - (time() - filemtime($otpFile))) . Lang::T(' seconds before sending another SMS'));
+        if (file_exists($otpFile) && time() - filemtime($otpFile) < (int)$_c['otp_wait']) {
+            r2(getUrl('accounts/phone-update'), 'e', Lang::T('Please wait ') . ((int)$_c['otp_wait'] - (time() - filemtime($otpFile))) . Lang::T(' seconds before sending another SMS'));
         } else {
             $otp = rand(100000, 999999);
             file_put_contents($otpFile, $otp);
@@ -254,7 +254,7 @@ switch ($action) {
         }
 
         // expired 10 minutes
-        if (time() - filemtime($otpFile) > 1200) {
+        if (time() - filemtime($otpFile) > (int)$_c['otp_expiry']) {
             unlink($otpFile);
             unlink($phoneFile);
             r2(getUrl('accounts/phone-update'), 'e', Lang::T('Verification code expired'));
@@ -323,8 +323,8 @@ switch ($action) {
         $emailFile = $otpPath . sha1($username . $db_pass) . "_email.txt";
 
         // expired 10 minutes
-        if (file_exists($otpFile) && time() - filemtime($otpFile) < 600) {
-            r2(getUrl('accounts/email-update'), 'e', Lang::T('Please wait ') . (600 - (time() - filemtime($otpFile))) . Lang::T(' seconds before sending another Email'));
+        if (file_exists($otpFile) && time() - filemtime($otpFile) < (int)$_c['otp_wait']) {
+            r2(getUrl('accounts/email-update'), 'e', Lang::T('Please wait ') . ((int)$_c['otp_wait'] - (time() - filemtime($otpFile))) . Lang::T(' seconds before sending another Email'));
         } else {
             $otp = rand(100000, 999999);
             file_put_contents($otpFile, $otp);
@@ -367,7 +367,7 @@ switch ($action) {
         }
 
         // expired 10 minutes
-        if (time() - filemtime($otpFile) > 1200) {
+        if (time() - filemtime($otpFile) > (int)$_c['otp_expiry']) {
             unlink($otpFile);
             unlink($emailFile);
             r2(getUrl('accounts/email-update'), 'e', Lang::T('Verification code expired'));

--- a/system/controllers/forgot.php
+++ b/system/controllers/forgot.php
@@ -29,7 +29,7 @@ if ($step == 1) {
         $user = ORM::for_table('tbl_customers')->selects(['phonenumber', 'email'])->where('username', $username)->find_one();
         if ($user) {
             $otpPath .= sha1($username . $db_pass) . ".txt";
-            if (file_exists($otpPath) && time() - filemtime($otpPath) < 600) {
+            if (file_exists($otpPath) && time() - filemtime($otpPath) < (int)$_c['otp_wait']) {
                 $sec = time() - filemtime($otpPath);
                 $ui->assign('notify_t', 's');
                 $ui->assign('notify', Lang::T("Verification Code already Sent to Your Phone/Email/Whatsapp, please wait")." $sec seconds.");
@@ -66,7 +66,7 @@ if ($step == 1) {
     $otp_code = _post('otp_code');
     if (!empty($username) && !empty($otp_code)) {
         $otpPath .= sha1($username . $db_pass) . ".txt";
-        if (file_exists($otpPath) && time() - filemtime($otpPath) <= 600) {
+        if (file_exists($otpPath) && time() - filemtime($otpPath) <= (int)$_c['otp_expiry']) {
             $otp = file_get_contents($otpPath);
             if ($otp == $otp_code) {
                 $pass = mt_rand(10000, 99999);
@@ -108,7 +108,7 @@ if ($step == 1) {
         $users = ORM::for_table('tbl_customers')->selects(['username', 'phonenumber', 'email'])->where('phonenumber', $find)->find_array();
         if ($users) {
             // prevent flooding only can request every 10 minutes
-            if (!file_exists($otpPath) || (file_exists($otpPath) && time() - filemtime($otpPath) >= 600)) {
+            if (!file_exists($otpPath) || (file_exists($otpPath) && time() - filemtime($otpPath) >= (int)$_c['otp_wait'])) {
                 $usernames = implode(", ", array_column($users, 'username'));
                 if ($via == 'sms') {
                     Message::sendSMS($find, Lang::T("Your username for") . ' ' . $config['CompanyName'] . "\n" . $usernames);
@@ -124,7 +124,7 @@ if ($step == 1) {
             $users = ORM::for_table('tbl_customers')->selects(['username', 'phonenumber', 'email'])->where('email', $find)->find_array();
             if ($users) {
                 // prevent flooding only can request every 10 minutes
-                if (!file_exists($otpPath) || (file_exists($otpPath) && time() - filemtime($otpPath) >= 600)) {
+                if (!file_exists($otpPath) || (file_exists($otpPath) && time() - filemtime($otpPath) >= (int)$_c['otp_wait'])) {
                     $usernames = implode(", ", array_column($users, 'username'));
                     $phones = [];
                     foreach ($users as $user) {

--- a/system/controllers/register.php
+++ b/system/controllers/register.php
@@ -54,8 +54,8 @@ switch ($do) {
         if ($_c['sms_otp_registration'] == 'yes') {
             $otpPath .= sha1("$phone_number$db_pass") . ".txt";
             run_hook('validate_otp'); #HOOK
-            // Expire after 10 minutes
-            if (file_exists($otpPath) && time() - filemtime($otpPath) > 1200) {
+            // Expire after configured time
+            if (file_exists($otpPath) && time() - filemtime($otpPath) > (int)$_c['otp_expiry']) {
                 unlink($otpPath);
                 r2(getUrl('register'), 's', 'Verification code expired');
             } else if (file_exists($otpPath)) {
@@ -214,9 +214,9 @@ switch ($do) {
                     touch($otpPath . 'index.html');
                 }
                 $otpPath .= sha1($phone_number . $db_pass) . ".txt";
-                if (file_exists($otpPath) && time() - filemtime($otpPath) < 600) {
+                if (file_exists($otpPath) && time() - filemtime($otpPath) < (int)$_c['otp_wait']) {
                     $ui->assign('phone_number', $phone_number);
-                    $ui->assign('notify', 'Please wait ' . (600 - (time() - filemtime($otpPath))) . ' seconds before sending another SMS');
+                    $ui->assign('notify', 'Please wait ' . ((int)$_c['otp_wait'] - (time() - filemtime($otpPath))) . ' seconds before sending another SMS');
                     $ui->assign('notify_t', 'd');
                     $ui->assign('_title', Lang::T('Register'));
                     $ui->display('customer/register-otp.tpl');

--- a/ui/ui/admin/settings/miscellaneous.tpl
+++ b/ui/ui/admin/settings/miscellaneous.tpl
@@ -95,11 +95,25 @@
                                     {Lang::T('Yes')}
                                 </option>
                             </select>
-                        </div>
-                        <p class="help-block col-md-4"><small>
+                    </div>
+                    <p class="help-block col-md-4"><small>
                                 {Lang::T('OTP is required when user want to change Email Address')}
                             </small>
                         </p>
+                    </div>
+                    <div class="form-group">
+                        <label class="col-md-3 control-label">{Lang::T('OTP Wait Time')}</label>
+                        <div class="col-md-5">
+                            <input type="number" name="otp_wait" id="otp_wait" class="form-control" value="{$_c['otp_wait']}">
+                        </div>
+                        <p class="help-block col-md-4"><small>{Lang::T('Seconds before a new OTP can be requested')}</small></p>
+                    </div>
+                    <div class="form-group">
+                        <label class="col-md-3 control-label">{Lang::T('OTP Expiry')}</label>
+                        <div class="col-md-5">
+                            <input type="number" name="otp_expiry" id="otp_expiry" class="form-control" value="{$_c['otp_expiry']}">
+                        </div>
+                        <p class="help-block col-md-4"><small>{Lang::T('Validity duration in seconds for an OTP')}</small></p>
                     </div>
                     <div class="form-group">
                         <label class="col-md-3 control-label">{Lang::T('Show Bandwidth Plan')}</label>


### PR DESCRIPTION
## Summary
- set default `otp_wait` and `otp_expiry` when app config lacks them
- seed new OTP options in installer and expose fields in admin misc settings
- replace hard-coded OTP timeouts with config-driven values across controllers
- document OTP timing options in README

## Testing
- `php -l init.php`
- `php -l system/controllers/accounts.php`
- `php -l system/controllers/register.php`
- `php -l system/controllers/forgot.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad2645b598832a8bb5b09eb2a1a56d