### PR TITLE
Use error redirects for registration failures

### DIFF
--- a/system/controllers/register.php
+++ b/system/controllers/register.php
@@ -57,7 +57,7 @@ switch ($do) {
             // Expire after configured time
             if (file_exists($otpPath) && time() - filemtime($otpPath) > (int)$_c['otp_expiry']) {
                 unlink($otpPath);
-                r2(getUrl('register'), 's', 'Verification code expired');
+                r2(getUrl('register'), 'e', 'Verification code expired');
             } else if (file_exists($otpPath)) {
                 $code = file_get_contents($otpPath);
                 if ($code != $otp_code) {
@@ -75,7 +75,7 @@ switch ($do) {
                     unlink($otpPath);
                 }
             } else {
-                r2(getUrl('register'), 's', 'No Verification code');
+                r2(getUrl('register'), 'e', 'No Verification code');
             }
         }
 
@@ -203,11 +203,11 @@ switch ($do) {
             if (!empty($phone_number)) {
                 $d = ORM::for_table('tbl_customers')->where('username', $phone_number)->find_one();
                 if ($d) {
-                    r2(getUrl('register'), 's', Lang::T('Account already exists'));
+                    r2(getUrl('register'), 'e', Lang::T('Account already exists'));
                 }
                 $d = ORM::for_table('tbl_customers')->where('phonenumber', $phone_number)->find_one();
                 if ($d) {
-                    r2(getUrl('register'), 's', Lang::T('Phone number already exists'));
+                    r2(getUrl('register'), 'e', Lang::T('Phone number already exists'));
                 }
                 if (!file_exists($otpPath)) {
                     mkdir($otpPath);


### PR DESCRIPTION
## Summary
- Treat expired or missing OTP codes as errors during registration
- Return error status when account or phone number already exists

## Testing
- `php -l system/controllers/register.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad46a54918832a86365f862092dd4b