### PR TITLE
Handle WhatsApp OTP send failures

### DIFF
--- a/system/autoload/Message.php
+++ b/system/autoload/Message.php
@@ -112,6 +112,13 @@ class Message
 
             try {
                 $response = Http::getData($waurl);
+                if (
+                    stripos($response, 'not registered') !== false ||
+                    stripos($response, 'failed') !== false
+                ) {
+                    self::logMessage('WhatsApp HTTP Response', $phone, $txt, 'Error', $response);
+                    return false;
+                }
                 self::logMessage('WhatsApp HTTP Response', $phone, $txt, 'Success', $response);
                 return $response;
             } catch (Throwable $e) {

--- a/system/controllers/accounts.php
+++ b/system/controllers/accounts.php
@@ -214,10 +214,16 @@ switch ($action) {
             if ($config['phone_otp_type'] === 'sms') {
                 Message::sendSMS($phone, $config['CompanyName'] . "\n\n" . Lang::T("Verification code") . "\n$otp");
             } elseif ($config['phone_otp_type'] === 'whatsapp') {
-                Message::sendWhatsapp($phone, $config['CompanyName'] . "\n\n" . Lang::T("Verification code") . "\n$otp");
+                $waSent = Message::sendWhatsapp($phone, $config['CompanyName'] . "\n\n" . Lang::T("Verification code") . "\n$otp");
+                if ($waSent === false) {
+                    r2(getUrl('accounts/phone-update'), 'e', Lang::T('OTP not sent: phone number isn\'t registered on WhatsApp'));
+                }
             } elseif ($config['phone_otp_type'] === 'both') {
                 Message::sendSMS($phone, $config['CompanyName'] . "\n\n" . Lang::T("Verification code") . "\n$otp");
-                Message::sendWhatsapp($phone, $config['CompanyName'] . "\n\n" . Lang::T("Verification code") . "\n$otp");
+                $waSent = Message::sendWhatsapp($phone, $config['CompanyName'] . "\n\n" . Lang::T("Verification code") . "\n$otp");
+                if ($waSent === false) {
+                    r2(getUrl('accounts/phone-update'), 'e', Lang::T('OTP not sent: phone number isn\'t registered on WhatsApp'));
+                }
             }
             //redirect after sending OTP
             r2(getUrl('accounts/phone-update'), 'e', Lang::T('Verification code has been sent to your phone'));

--- a/system/controllers/forgot.php
+++ b/system/controllers/forgot.php
@@ -42,16 +42,28 @@ if ($step == 1) {
                 file_put_contents($otpPath, $otp);
                 if ($via == 'sms') {
                     Message::sendSMS($user['phonenumber'], $config['CompanyName'] . " C0de: $otp");
+                    Message::sendEmail(
+                        $user['email'],
+                        $config['CompanyName'] . Lang::T("Your Verification Code") . ' : ' . $otp,
+                        Lang::T("Your Verification Code") . ' : <b>' . $otp . '</b>'
+                    );
+                    $ui->assign('notify_t', 's');
+                    $ui->assign('notify', Lang::T("If your Username is found, Verification Code has been Sent to Your Phone/Email/Whatsapp"));
                 } else {
-                    Message::sendWhatsapp($user['phonenumber'], $config['CompanyName'] . " C0de: $otp");
+                    $waSent = Message::sendWhatsapp($user['phonenumber'], $config['CompanyName'] . " C0de: $otp");
+                    Message::sendEmail(
+                        $user['email'],
+                        $config['CompanyName'] . Lang::T("Your Verification Code") . ' : ' . $otp,
+                        Lang::T("Your Verification Code") . ' : <b>' . $otp . '</b>'
+                    );
+                    if ($waSent === false) {
+                        $ui->assign('notify_t', 'e');
+                        $ui->assign('notify', Lang::T('OTP not sent: phone number isn\'t registered on WhatsApp'));
+                    } else {
+                        $ui->assign('notify_t', 's');
+                        $ui->assign('notify', Lang::T("If your Username is found, Verification Code has been Sent to Your Phone/Email/Whatsapp"));
+                    }
                 }
-                Message::sendEmail(
-                    $user['email'],
-                    $config['CompanyName'] . Lang::T("Your Verification Code") . ' : ' . $otp,
-                    Lang::T("Your Verification Code") . ' : <b>' . $otp . '</b>'
-                );
-                $ui->assign('notify_t', 's');
-                $ui->assign('notify', Lang::T("If your Username is found, Verification Code has been Sent to Your Phone/Email/Whatsapp"));
             }
         } else {
             // Username not found

--- a/system/controllers/register.php
+++ b/system/controllers/register.php
@@ -224,9 +224,25 @@ switch ($do) {
                     $otp = rand(100000, 999999);
                     file_put_contents($otpPath, $otp);
                     if ($config['phone_otp_type'] == 'whatsapp') {
-                        Message::sendWhatsapp($phone_number, $config['CompanyName'] . "\n\n" . Lang::T("Registration code") . "\n$otp");
+                        $waSent = Message::sendWhatsapp($phone_number, $config['CompanyName'] . "\n\n" . Lang::T("Registration code") . "\n$otp");
+                        if ($waSent === false) {
+                            $ui->assign('phone_number', $phone_number);
+                            $ui->assign('notify', Lang::T('OTP not sent: phone number isn\'t registered on WhatsApp'));
+                            $ui->assign('notify_t', 'd');
+                            $ui->assign('_title', Lang::T('Register'));
+                            $ui->display('customer/register-otp.tpl');
+                            return;
+                        }
                     } else if ($config['phone_otp_type'] == 'both') {
-                        Message::sendWhatsapp($phone_number, $config['CompanyName'] . "\n\n" . Lang::T("Registration code") . "\n$otp");
+                        $waSent = Message::sendWhatsapp($phone_number, $config['CompanyName'] . "\n\n" . Lang::T("Registration code") . "\n$otp");
+                        if ($waSent === false) {
+                            $ui->assign('phone_number', $phone_number);
+                            $ui->assign('notify', Lang::T('OTP not sent: phone number isn\'t registered on WhatsApp'));
+                            $ui->assign('notify_t', 'd');
+                            $ui->assign('_title', Lang::T('Register'));
+                            $ui->display('customer/register-otp.tpl');
+                            return;
+                        }
                         Message::sendSMS($phone_number, $config['CompanyName'] . "\n\n" . Lang::T("Registration code") . "\n$otp");
                     } else {
                         Message::sendSMS($phone_number, $config['CompanyName'] . "\n\n" . Lang::T("Registration code") . "\n$otp");


### PR DESCRIPTION
## Summary
- detect WhatsApp delivery failures and log them, returning `false` to callers
- surface WhatsApp OTP send failures in account update, registration, and password reset flows

## Testing
- `php -l system/autoload/Message.php system/controllers/accounts.php system/controllers/register.php system/controllers/forgot.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad477f079c832aa1bfeb0e4aeac2a6