### PR TITLE
Add reusable phone number validator

### DIFF
--- a/system/autoload/Validator.php
+++ b/system/autoload/Validator.php
@@ -301,6 +301,21 @@ class Validator
         return (bool)in_array($format, $formats);
     }
 
+    /**
+     * Phone number with country code (62) or leading zero
+     *
+     * @access public
+     * @param string $number
+     * @return bool
+     */
+    public static function PhoneWithCountry($number)
+    {
+        global $config;
+        $code = isset($config['country_code_phone']) ? preg_replace('/\D/', '', $config['country_code_phone']) : '';
+        $pattern = $code === '' ? '/^0[0-9]+$/' : '/^(' . $code . '|0)[0-9]+$/';
+        return (bool)preg_match($pattern, $number);
+    }
+
     public static function countRouterPlan($plans, $router)
     {
         $n = 0;

--- a/system/controllers/accounts.php
+++ b/system/controllers/accounts.php
@@ -92,8 +92,8 @@ switch ($action) {
         if (Validator::Length($fullname, 31, 1) == false) {
             $msg .= 'Full Name should be between 1 to 30 characters' . '<br>';
         }
-        if (Validator::UnsignedNumber($phonenumber) == false) {
-            $msg .= 'Phone Number must be a number' . '<br>';
+        if (!Validator::PhoneWithCountry($phonenumber)) {
+            $msg .= Lang::T('Invalid phone number; start with 62 or 0') . '<br>';
         }
 
         if (empty($msg)) {
@@ -184,8 +184,8 @@ switch ($action) {
         $otpPath = $CACHE_PATH . '/sms/';
         $_SESSION['new_phone'] = $phone;
         // Validate the phone number format
-        if (!preg_match('/^[0-9]{10,}$/', $phone) || empty($phone)) {
-            r2(getUrl('accounts/phone-update'), 'e', Lang::T('Invalid phone number format'));
+        if (!Validator::PhoneWithCountry($phone)) {
+            r2(getUrl('accounts/phone-update'), 'e', Lang::T('Invalid phone number; start with 62 or 0'));
         }
 
         if (empty($config['sms_url'])) {
@@ -242,8 +242,8 @@ switch ($action) {
         $otpPath = $CACHE_PATH . '/sms/';
 
         // Validate the phone number format
-        if (!preg_match('/^[0-9]{10,}$/', $phone)) {
-            r2(getUrl('accounts/phone-update'), 'e', Lang::T('Invalid phone number format'));
+        if (!Validator::PhoneWithCountry($phone)) {
+            r2(getUrl('accounts/phone-update'), 'e', Lang::T('Invalid phone number; start with 62 or 0'));
         }
 
         if (empty($config['sms_url'])) {

--- a/system/controllers/customers.php
+++ b/system/controllers/customers.php
@@ -495,6 +495,9 @@ switch ($action) {
         if (!Validator::Length($password, 36, 2)) {
             $msg .= 'Password should be between 3 to 35 characters' . '<br>';
         }
+        if (!Validator::PhoneWithCountry($phonenumber)) {
+            $msg .= Lang::T('Invalid phone number; start with 62 or 0') . '<br>';
+        }
 
         $d = ORM::for_table('tbl_customers')->where('username', $username)->find_one();
         if ($d) {
@@ -609,7 +612,8 @@ switch ($action) {
         $pppoe_ip = trim(_post('pppoe_ip'));
         $email = _post('email');
         $address = _post('address');
-        $phonenumber = Lang::phoneFormat(_post('phonenumber'));
+        $phonenumber_raw = _post('phonenumber');
+        $phonenumber = Lang::phoneFormat($phonenumber_raw);
         $service_type = _post('service_type');
         $coordinates = _post('coordinates');
         $status = _post('status');
@@ -625,6 +629,10 @@ switch ($action) {
         }
         if (Validator::Length($fullname, 36, 1) == false) {
             $msg .= 'Full Name should be between 2 to 25 characters' . '<br>';
+        }
+
+        if (!Validator::PhoneWithCountry($phonenumber_raw)) {
+            $msg .= Lang::T('Invalid phone number; start with 62 or 0') . '<br>';
         }
 
         $c = ORM::for_table('tbl_customers')->find_one($id);

--- a/system/controllers/register.php
+++ b/system/controllers/register.php
@@ -79,6 +79,11 @@ switch ($do) {
             }
         }
 
+        // Validate phone number format
+        if (!Validator::PhoneWithCountry($phone_number)) {
+            $msg .= Lang::T('Invalid phone number; start with 62 or 0') . '<br>';
+        }
+
         // Check if username already exists
         $d = ORM::for_table('tbl_customers')->where('username', $username)->find_one();
         if ($d) {
@@ -201,6 +206,9 @@ switch ($do) {
         if ($_c['sms_otp_registration'] == 'yes') {
             $phone_number = _post('phone_number');
             if (!empty($phone_number)) {
+                if (!Validator::PhoneWithCountry($phone_number)) {
+                    r2(getUrl('register'), 'e', Lang::T('Invalid phone number; start with 62 or 0'));
+                }
                 $d = ORM::for_table('tbl_customers')->where('username', $phone_number)->find_one();
                 if ($d) {
                     r2(getUrl('register'), 'e', Lang::T('Account already exists'));


### PR DESCRIPTION
## Summary
- add Validator::PhoneWithCountry for numbers beginning with configured country code or 0
- apply phone validation in registration and OTP flows
- enforce phone validation in customer management and account self-service updates

## Testing
- `php -l system/autoload/Validator.php`
- `php -l system/controllers/register.php`
- `php -l system/controllers/customers.php`
- `php -l system/controllers/accounts.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad5084444c832aaccaada7b7a7e5af