### PR TITLE
Enforce numeric country code for localisation settings

### DIFF
--- a/system/controllers/settings.php
+++ b/system/controllers/settings.php
@@ -400,6 +400,10 @@ switch ($action) {
         $tzone = _post('tzone');
         $date_format = _post('date_format');
         $country_code_phone = _post('country_code_phone');
+        if (!ctype_digit($country_code_phone)) {
+            r2(getUrl('settings/localisation'), 'e', Lang::T('Country code must contain digits only'));
+        }
+        $country_code_phone = preg_replace('/\D/', '', $country_code_phone);
         $lan = _post('lan');
         run_hook('save_localisation'); #HOOK
         if ($tzone == '' or $date_format == '' or $lan == '') {

--- a/ui/ui/admin/settings/localisation.tpl
+++ b/ui/ui/admin/settings/localisation.tpl
@@ -101,8 +101,14 @@
                         <div class="col-md-6">
                             <div class="input-group">
                                 <span class="input-group-addon" id="basic-addon1">+</span>
-                                <input type="text" class="form-control" id="country_code_phone" placeholder="62"
-                                    name="country_code_phone" value="{$_c['country_code_phone']}">
+                                <input type="text"
+                                    pattern="\d+"
+                                    inputmode="numeric"
+                                    class="form-control"
+                                    id="country_code_phone"
+                                    name="country_code_phone"
+                                    placeholder="62"
+                                    value="{$_c['country_code_phone']}">
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Limit Country Code Phone field to digits using HTML attributes
- Validate and sanitize country code server-side before saving

## Testing
- `php -l system/controllers/settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad5620ee40832a852ca6b09e5eefac