### PR TITLE
Ensure OTP failure halts further execution

### DIFF
--- a/system/controllers/forgot.php
+++ b/system/controllers/forgot.php
@@ -98,15 +98,18 @@ if ($step == 1) {
                 setcookie('forgot_username', '', time() - 3600, '/');
             } else {
                 r2(getUrl('forgot&step=1'), 'e', Lang::T('Invalid Username or Verification Code'));
+                return;
             }
         } else {
             if (file_exists($otpPath)) {
                 unlink($otpPath);
             }
             r2(getUrl('forgot&step=1'), 'e', Lang::T('Invalid Username or Verification Code'));
+            return;
         }
     } else {
         r2(getUrl('forgot&step=1'), 'e', Lang::T('Invalid Username or Verification Code'));
+        return;
     }
 } else if ($step == 7) {
     $find = _post('find');


### PR DESCRIPTION
## Summary
- stop processing after OTP phone update failures by returning immediately
- ensure email update OTP failures return without executing remaining logic
- return early on invalid username or OTP in forgot password flow

## Testing
- `php -l system/controllers/accounts.php`
- `php -l system/controllers/forgot.php`
- `php -r '...include "system/controllers/forgot.php"...'` *(fails: Call to undefined function _req())*
- `php -r '...include "system/controllers/accounts.php"...'` *(fails: Call to undefined function _auth())*

------
https://chatgpt.com/codex/tasks/task_e_68ad8d9a6b5c832a9b23f5e52c9957bd