### PR TITLE
Normalize phone number handling across user flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ OTP timing can be tuned through two settings available in Admin → Settings →
 - `otp_wait` – seconds before a new OTP can be requested.
 - `otp_expiry` – seconds before an OTP becomes invalid.
 
+### Phone Number Formatting
+
+Ensure the **country_code_phone** setting is configured in Admin → Settings → Localisation. All modules should normalize phone numbers using `Lang::phoneFormat` before storing or comparing values to maintain consistency across the system.
+
 ## Freeradius
 
 Support [Freeradius with Database](https://github.com/hotspotbilling/phpnuxbill/wiki/FreeRadius)

--- a/system/controllers/accounts.php
+++ b/system/controllers/accounts.php
@@ -86,13 +86,13 @@ switch ($action) {
         $fullname = _post('fullname');
         $address = _post('address');
         $email = _post('email');
-        $phonenumber = _post('phonenumber');
+        $raw = _post('phonenumber');
         run_hook('customer_edit_profile'); #HOOK
         $msg = '';
         if (Validator::Length($fullname, 31, 1) == false) {
             $msg .= 'Full Name should be between 1 to 30 characters' . '<br>';
         }
-        if (!Validator::PhoneWithCountry($phonenumber)) {
+        if (!Validator::PhoneWithCountry($raw)) {
             $msg .= Lang::T('Invalid phone number; start with 62 or 0') . '<br>';
         }
 
@@ -149,6 +149,7 @@ switch ($action) {
             $user->fullname = $fullname;
             $user->address = $address;
             if ($_c['allow_phone_otp'] != 'yes') {
+                $phonenumber = Lang::phoneFormat($raw);
                 $user->phonenumber = $phonenumber;
             }
             if ($_c['allow_email_otp'] != 'yes') {

--- a/system/controllers/forgot.php
+++ b/system/controllers/forgot.php
@@ -115,6 +115,7 @@ if ($step == 1) {
     $find = _post('find');
     $step = 6;
     if (!empty($find)) {
+        $formatted = Lang::phoneFormat($find);
         $via = $config['user_notification_reminder'];
         if ($via == 'email') {
             $via = 'sms';
@@ -122,16 +123,16 @@ if ($step == 1) {
         if (!file_exists($otpPath)) {
             mkdir($otpPath);
         }
-        $otpPath .= sha1($find . $db_pass) . ".txt";
-        $users = ORM::for_table('tbl_customers')->selects(['username', 'phonenumber', 'email'])->where('phonenumber', $find)->find_array();
+        $otpPath .= sha1($formatted . $db_pass) . ".txt";
+        $users = ORM::for_table('tbl_customers')->selects(['username', 'phonenumber', 'email'])->where('phonenumber', $formatted)->find_array();
         if ($users) {
             // prevent flooding only can request every 10 minutes
             if (!file_exists($otpPath) || (file_exists($otpPath) && time() - filemtime($otpPath) >= (int)$_c['otp_wait'])) {
                 $usernames = implode(", ", array_column($users, 'username'));
                 if ($via == 'sms') {
-                    Message::sendSMS($find, Lang::T("Your username for") . ' ' . $config['CompanyName'] . "\n" . $usernames);
+                    Message::sendSMS($formatted, Lang::T("Your username for") . ' ' . $config['CompanyName'] . "\n" . $usernames);
                 } else {
-                    Message::sendWhatsapp($find, Lang::T("Your username for") . ' ' . $config['CompanyName'] . "\n" . $usernames);
+                    Message::sendWhatsapp($formatted, Lang::T("Your username for") . ' ' . $config['CompanyName'] . "\n" . $usernames);
                 }
                 file_put_contents($otpPath, time());
             }

--- a/system/controllers/register.php
+++ b/system/controllers/register.php
@@ -84,6 +84,9 @@ switch ($do) {
             $msg .= Lang::T('Invalid phone number; start with 62 or 0') . '<br>';
         }
 
+        // Normalize phone number for storage and comparison
+        $formatted = Lang::phoneFormat($phone_number);
+
         // Check if username already exists
         $d = ORM::for_table('tbl_customers')->where('username', $username)->find_one();
         if ($d) {
@@ -91,7 +94,7 @@ switch ($do) {
         }
 
         // Check if phone number already exists
-        $d = ORM::for_table('tbl_customers')->where('phonenumber', $phone_number)->find_one();
+        $d = ORM::for_table('tbl_customers')->where('phonenumber', $formatted)->find_one();
         if ($d) {
             $msg .= Lang::T('Phone number already exists') . '<br>';
         }
@@ -103,7 +106,7 @@ switch ($do) {
             $d->fullname = $fullname;
             $d->address = $address;
             $d->email = $email;
-            $d->phonenumber = $phone_number;
+            $d->phonenumber = $formatted;
             if ($d->save()) {
                 $user = $d->id();
                 if ($config['photo_register'] == 'yes' && !empty($_FILES['photo']['name']) && file_exists($_FILES['photo']['tmp_name'])) {
@@ -209,6 +212,7 @@ switch ($do) {
                 if (!Validator::PhoneWithCountry($phone_number)) {
                     r2(getUrl('register'), 'e', Lang::T('Invalid phone number; start with 62 or 0'));
                 }
+                $phone_number = Lang::phoneFormat($phone_number);
                 $d = ORM::for_table('tbl_customers')->where('username', $phone_number)->find_one();
                 if ($d) {
                     r2(getUrl('register'), 'e', Lang::T('Account already exists'));


### PR DESCRIPTION
## Summary
- Normalize phone number in registration, OTP validation, and persistence
- Require phone normalization during profile edits and username recovery
- Document `country_code_phone` setting and mandate `Lang::phoneFormat` usage

## Testing
- `php -l system/controllers/register.php`
- `php -l system/controllers/accounts.php`
- `php -l system/controllers/forgot.php`


------
https://chatgpt.com/codex/tasks/task_e_68ada78d6c64832abcf5c4ede1e750da