### PR TITLE
feat: use registration_username for input placeholders

### DIFF
--- a/ui/ui/admin/customers/add.tpl
+++ b/ui/ui/admin/customers/add.tpl
@@ -8,18 +8,26 @@
                 <div class="panel-heading">{Lang::T('Add New Contact')}</div>
                 <div class="panel-body">
                     <div class="form-group">
-                        <label class="col-md-3 control-label">{Lang::T('Username')}</label>
+                        <label class="col-md-3 control-label">
+                            {if $_c['registration_username'] == 'phone'}
+                                {Lang::T('Phone Number')}
+                            {elseif $_c['registration_username'] == 'email'}
+                                {Lang::T('Email')}
+                            {else}
+                                {Lang::T('Usernames')}
+                            {/if}
+                        </label>
                         <div class="col-md-9">
                             <div class="input-group">
-                                {if $_c['country_code_phone'] != ''}
-                                    <span class="input-group-addon" id="basic-addon1"><i
-                                            class="glyphicon glyphicon-phone-alt"></i></span>
+                                {if $_c['registration_username'] == 'phone'}
+                                    <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-phone-alt"></i></span>
+                                {elseif $_c['registration_username'] == 'email'}
+                                    <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-envelope"></i></span>
                                 {else}
-                                    <span class="input-group-addon" id="basic-addon1"><i
-                                            class="glyphicon glyphicon-user"></i></span>
+                                    <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-user"></i></span>
                                 {/if}
                                 <input type="text" class="form-control" name="username" required
-                                    placeholder="{if $_c['country_code_phone']!= ''}{$_c['country_code_phone']} {Lang::T('Phone Number')}{else}{Lang::T('Usernames')}{/if}">
+                                    placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
                             </div>
                         </div>
                     </div>

--- a/ui/ui/admin/customers/edit.tpl
+++ b/ui/ui/admin/customers/edit.tpl
@@ -24,19 +24,27 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <label class="col-md-3 control-label">{Lang::T('Usernames')}</label>
+                        <label class="col-md-3 control-label">
+                            {if $_c['registration_username'] == 'phone'}
+                                {Lang::T('Phone Number')}
+                            {elseif $_c['registration_username'] == 'email'}
+                                {Lang::T('Email')}
+                            {else}
+                                {Lang::T('Usernames')}
+                            {/if}
+                        </label>
                         <div class="col-md-9">
                             <div class="input-group">
-                                {if $_c['country_code_phone']!= ''}
-                                    <span class="input-group-addon" id="basic-addon1"><i
-                                            class="glyphicon glyphicon-phone-alt"></i></span>
+                                {if $_c['registration_username'] == 'phone'}
+                                    <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-phone-alt"></i></span>
+                                {elseif $_c['registration_username'] == 'email'}
+                                    <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-envelope"></i></span>
                                 {else}
-                                    <span class="input-group-addon" id="basic-addon1"><i
-                                            class="glyphicon glyphicon-user"></i></span>
+                                    <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-user"></i></span>
                                 {/if}
                                 <input type="text" class="form-control" name="username" value="{$d['username']}"
                                     required
-                                    placeholder="{if $_c['country_code_phone']!= ''}{$_c['country_code_phone']} {Lang::T('Phone Number')}{else}{Lang::T('Usernames')}{/if}">
+                                    placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
                             </div>
                         </div>
                     </div>

--- a/ui/ui/customer/forgot.tpl
+++ b/ui/ui/customer/forgot.tpl
@@ -10,13 +10,15 @@
                     <div class="panel-body">
                         <div class="form-group">
                             <div class="input-group">
-                                {if $_c['country_code_phone']!= ''}
+                                {if $_c['registration_username'] == 'phone'}
                                     <span class="input-group-addon"><i class="glyphicon glyphicon-phone-alt"></i></span>
+                                {elseif $_c['registration_username'] == 'email'}
+                                    <span class="input-group-addon"><i class="glyphicon glyphicon-envelope"></i></span>
                                 {else}
                                     <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
                                 {/if}
                                 <input type="text" readonly class="form-control" name="username" value="{$username}"
-                                    placeholder="{if $_c['country_code_phone']!= ''}{$_c['country_code_phone']} {Lang::T('Phone Number')}{else}{Lang::T('Usernames')}{/if}">
+                                    placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
                             </div>
                         </div>
                         <div class="form-group">
@@ -37,15 +39,25 @@
                     <div class="panel-heading">{Lang::T('Success')}</div>
                     <div class="panel-body">
                         <div class="form-group">
-                            <label>{if $_c['country_code_phone']!= ''}{Lang::T('Phone Number')}{else}{Lang::T('Usernames')}{/if}</label>
+                            <label>
+                                {if $_c['registration_username'] == 'phone'}
+                                    {Lang::T('Phone Number')}
+                                {elseif $_c['registration_username'] == 'email'}
+                                    {Lang::T('Email')}
+                                {else}
+                                    {Lang::T('Usernames')}
+                                {/if}
+                            </label>
                             <div class="input-group">
-                                {if $_c['country_code_phone']!= ''}
+                                {if $_c['registration_username'] == 'phone'}
                                     <span class="input-group-addon"><i class="glyphicon glyphicon-phone-alt"></i></span>
+                                {elseif $_c['registration_username'] == 'email'}
+                                    <span class="input-group-addon"><i class="glyphicon glyphicon-envelope"></i></span>
                                 {else}
                                     <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
                                 {/if}
                                 <input type="text" readonly class="form-control" name="username" value="{$username}"
-                                    placeholder="{if $_c['country_code_phone']!= ''}{$_c['country_code_phone']} {Lang::T('Phone Number')}{else}{Lang::T('Usernames')}{/if}">
+                                    placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
                             </div>
                         </div>
                         <label>{Lang::T('Your Password has been change to')}</label>
@@ -74,15 +86,25 @@
                     <div class="panel-heading">{Lang::T('Forgot Password')}</div>
                     <div class="panel-body">
                         <div class="form-group">
-                            <label>{if $_c['country_code_phone']!= ''}{Lang::T('Phone Number')}{else}{Lang::T('Usernames')}{/if}</label>
+                            <label>
+                                {if $_c['registration_username'] == 'phone'}
+                                    {Lang::T('Phone Number')}
+                                {elseif $_c['registration_username'] == 'email'}
+                                    {Lang::T('Email')}
+                                {else}
+                                    {Lang::T('Usernames')}
+                                {/if}
+                            </label>
                             <div class="input-group">
-                                {if $_c['country_code_phone']!= ''}
+                                {if $_c['registration_username'] == 'phone'}
                                     <span class="input-group-addon"><i class="glyphicon glyphicon-phone-alt"></i></span>
+                                {elseif $_c['registration_username'] == 'email'}
+                                    <span class="input-group-addon"><i class="glyphicon glyphicon-envelope"></i></span>
                                 {else}
                                     <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
                                 {/if}
                                 <input type="text" class="form-control" name="username" required
-                                    placeholder="{if $_c['country_code_phone']!= ''}{$_c['country_code_phone']} {Lang::T('Phone Number')}{else}{Lang::T('Usernames')}{/if}">
+                                    placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
                             </div>
                         </div>
                     </div>

--- a/ui/ui/customer/login-custom-moon.tpl
+++ b/ui/ui/customer/login-custom-moon.tpl
@@ -587,7 +587,7 @@
                                 <input type="hidden" name="csrf_token" value="{$csrf_token}">
                                 <div>
                                     <input type="text" name="username"
-                                        placeholder="{if $_c['registration_username'] == 'phone'}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}"
+                                        placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}"
                                         required>
                                 </div>
                                 <div>

--- a/ui/ui/customer/login-noreg.tpl
+++ b/ui/ui/customer/login-noreg.tpl
@@ -37,7 +37,7 @@
                                         class="glyphicon glyphicon-user"></i></span>
                             {/if}
                             <input type="text" class="form-control" name="username"
-                                placeholder="{if $_c['country_code_phone']!= '' || $_c['registration_username'] == 'phone'}{$_c['country_code_phone']} {Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
+                                placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
                         </div>
                     </div>
                     <div class="form-group">

--- a/ui/ui/customer/login.tpl
+++ b/ui/ui/customer/login.tpl
@@ -41,7 +41,7 @@
                                         class="glyphicon glyphicon-user"></i></span>
                             {/if}
                             <input type="text" class="form-control" name="username"
-                                placeholder="{if $_c['country_code_phone']!= '' || $_c['registration_username'] == 'phone'}{$_c['country_code_phone']} {Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
+                                placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
                         </div>
                     </div>
                     <div class="form-group">

--- a/ui/ui/customer/profile.tpl
+++ b/ui/ui/customer/profile.tpl
@@ -26,22 +26,27 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <label class="col-md-3 control-label">{Lang::T('Usernames')}</label>
+                        <label class="col-md-3 control-label">
+                            {if $_c['registration_username'] == 'phone'}
+                                {Lang::T('Phone Number')}
+                            {elseif $_c['registration_username'] == 'email'}
+                                {Lang::T('Email')}
+                            {else}
+                                {Lang::T('Usernames')}
+                            {/if}
+                        </label>
                         <div class="col-md-9">
                             <div class="input-group">
                                 {if $_c['registration_username'] == 'phone'}
-                                    <span class="input-group-addon" id="basic-addon1"><i
-                                            class="glyphicon glyphicon-phone-alt"></i></span>
+                                    <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-phone-alt"></i></span>
                                 {elseif $_c['registration_username'] == 'email'}
-                                    <span class="input-group-addon" id="basic-addon1"><i
-                                            class="glyphicon glyphicon-envelope"></i></span>
+                                    <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-envelope"></i></span>
                                 {else}
-                                    <span class="input-group-addon" id="basic-addon1"><i
-                                            class="glyphicon glyphicon-user"></i></span>
+                                    <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-user"></i></span>
                                 {/if}
                                 <input type="text" class="form-control" name="username" id="username" readonly
                                     value="{$_user['username']}"
-                                    placeholder="{if $_c['country_code_phone']!= '' || $_c['registration_username'] == 'phone'}{$_c['country_code_phone']} {Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Username')}{/if}">
+                                    placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
                             </div>
                         </div>
                     </div>

--- a/ui/ui/customer/reg-login-custom-moon.tpl
+++ b/ui/ui/customer/reg-login-custom-moon.tpl
@@ -359,7 +359,7 @@
                                 <div id="basicFields">
                                     <div class="form-group">
                                         <input type="text" name="username"
-                                            placeholder="{if $_c['country_code_phone']!= '' || $_c['registration_username'] == 'phone'}{$_c['country_code_phone']} {Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
+                                            placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
                                     </div>
                                     {if $_c['photo_register'] == 'yes'}
                                     <div class="form-group">

--- a/ui/ui/customer/register-otp.tpl
+++ b/ui/ui/customer/register-otp.tpl
@@ -18,13 +18,26 @@
                     <div class="form-container">
                         <!-- Phone Number Field -->
                         <div class="form-group">
-                            <label>{Lang::T('Phone Number')}</label>
+                            <label>
+                                {if $_c['registration_username'] == 'phone'}
+                                    {Lang::T('Phone Number')}
+                                {elseif $_c['registration_username'] == 'email'}
+                                    {Lang::T('Email')}
+                                {else}
+                                    {Lang::T('Usernames')}
+                                {/if}
+                            </label>
                             <div class="input-group">
-                                <span class="input-group-addon" id="basic-addon1"><i
-                                        class="glyphicon glyphicon-phone-alt"></i></span>
+                                {if $_c['registration_username'] == 'phone'}
+                                    <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-phone-alt"></i></span>
+                                {elseif $_c['registration_username'] == 'email'}
+                                    <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-envelope"></i></span>
+                                {else}
+                                    <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-user"></i></span>
+                                {/if}
                                 <input type="text" class="form-control" name="phone_number" value="{$phone_number}"
                                     readonly
-                                    placeholder="{if $_c['country_code_phone']!= '' || $_c['registration_username'] == 'phone'}{$_c['country_code_phone']} {Lang::T('Phone Number')}{else}{Lang::T('Phone Number')}{/if}">
+                                    placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
                             </div>
                         </div>
                         <div class="form-group">

--- a/ui/ui/customer/register-rotp.tpl
+++ b/ui/ui/customer/register-rotp.tpl
@@ -20,13 +20,24 @@
                 <div class="panel-body">
                     <div class="form-group">
                         <label>
-                            {Lang::T('Phone Number')}
+                            {if $_c['registration_username'] == 'phone'}
+                                {Lang::T('Phone Number')}
+                            {elseif $_c['registration_username'] == 'email'}
+                                {Lang::T('Email')}
+                            {else}
+                                {Lang::T('Usernames')}
+                            {/if}
                         </label>
                         <div class="input-group">
-                            <span class="input-group-addon" id="basic-addon1"><i
-                                    class="glyphicon glyphicon-phone-alt"></i></span>
+                            {if $_c['registration_username'] == 'phone'}
+                                <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-phone-alt"></i></span>
+                            {elseif $_c['registration_username'] == 'email'}
+                                <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-envelope"></i></span>
+                            {else}
+                                <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-user"></i></span>
+                            {/if}
                             <input type="text" class="form-control" name="phone_number"
-                                placeholder="{if $_c['country_code_phone']!= '' || $_c['registration_username'] == 'phone'}{$_c['country_code_phone']} {Lang::T('Phone Number')}{else}{Lang::T('Phone Number')}{/if}"
+                                placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}"
                                 inputmode="numeric" pattern="[0-9]*">
                         </div>
                     </div>

--- a/ui/ui/customer/register.tpl
+++ b/ui/ui/customer/register.tpl
@@ -38,7 +38,7 @@
                                             class="glyphicon glyphicon-user"></i></span>
                                 {/if}
                                 <input type="text" class="form-control" name="username"
-                                    placeholder="{if $_c['country_code_phone']!= '' || $_c['registration_username'] == 'phone'}{$_c['country_code_phone']} {Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
+                                    placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
                             </div>
                         </div>
                         {if $_c['photo_register'] == 'yes'}


### PR DESCRIPTION
## Summary
- use `registration_username` to render username labels, icons and placeholders
- ensure admin and client forms show phone/email hints based on settings

## Testing
- `composer validate --no-check-publish`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae8f1542b0832a97b2d12d860085a0