### PR TITLE
Support email login option

### DIFF
--- a/system/controllers/login.php
+++ b/system/controllers/login.php
@@ -66,9 +66,14 @@ switch ($do) {
         if ($username != '' and $password != '') {
             if ($_c['registration_username'] === 'phone') {
                 $username = Lang::phoneFormat($username);
-                $d = ORM::for_table('tbl_customers')->where('phonenumber', $username)->find_one();
+                $d = ORM::for_table('tbl_customers')
+                    ->where('phonenumber', $username)->find_one();
+            } elseif ($_c['registration_username'] === 'email') {
+                $d = ORM::for_table('tbl_customers')
+                    ->where('email', $username)->find_one();
             } else {
-                $d = ORM::for_table('tbl_customers')->where('username', $username)->find_one();
+                $d = ORM::for_table('tbl_customers')
+                    ->where('username', $username)->find_one();
             }
             if ($d) {
                 $d_pass = $d['password'];


### PR DESCRIPTION
## Summary
- expand login user lookup to handle `registration_username` set to `email`

## Testing
- `php -l system/controllers/login.php`
- `php /tmp/test_login.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae97f65570832ab7d9e1f6540dbcbd