### PR TITLE
Allow login with email

### DIFF
--- a/system/controllers/admin.php
+++ b/system/controllers/admin.php
@@ -21,7 +21,7 @@ if (isset($routes['1'])) {
 
 switch ($do) {
     case 'post':
-        $username = _post('username');
+        $username = strtolower(trim(_post('username')));
         $password = _post('password');
         //csrf token
         $csrf_token = _post('csrf_token');
@@ -73,7 +73,10 @@ switch ($do) {
             }
         }   
         if ($username != '' and $password != '') {
-            $d = ORM::for_table('tbl_users')->where('username', $username)->find_one();
+            $d = ORM::for_table('tbl_users')
+                ->where_raw('LOWER(username) = ?', $username)
+                ->or_where_raw('LOWER(email) = ?', $username)
+                ->find_one();
             if ($d) {
                 $d_pass = $d['password'];
                 if (Password::_verify($password, $d_pass) == true) {

--- a/system/controllers/login.php
+++ b/system/controllers/login.php
@@ -22,7 +22,7 @@ if (isset($routes['1'])) {
 
 switch ($do) {
     case 'post':
-        $username = _post('username');
+        $username = strtolower(trim(_post('username')));
         $password = _post('password');
         $csrf_token = _post('csrf_token');
         if (!Csrf::check($csrf_token)) {
@@ -68,12 +68,10 @@ switch ($do) {
                 $username = Lang::phoneFormat($username);
                 $d = ORM::for_table('tbl_customers')
                     ->where('phonenumber', $username)->find_one();
-            } elseif ($_c['registration_username'] === 'email') {
-                $d = ORM::for_table('tbl_customers')
-                    ->where('email', $username)->find_one();
             } else {
                 $d = ORM::for_table('tbl_customers')
-                    ->where('username', $username)->find_one();
+                    ->where('username', $username)
+                    ->or_where('email', $username)->find_one();
             }
             if ($d) {
                 $d_pass = $d['password'];

--- a/ui/ui/admin/admin/login.tpl
+++ b/ui/ui/admin/admin/login.tpl
@@ -48,7 +48,7 @@
             <form action="{Text::url('admin/post')}" method="post">
                 <input type="hidden" name="csrf_token" value="{$csrf_token}">
                 <div class="form-group has-feedback">
-                    <input type="text" required class="form-control" name="username" placeholder="{Lang::T('Username')}">
+                    <input type="text" required class="form-control" name="username" placeholder="{Lang::T('Username or Email')}">
                     <span class="glyphicon glyphicon-user form-control-feedback"></span>
                 </div>
                 <div class="form-group has-feedback">

--- a/ui/ui/customer/login.tpl
+++ b/ui/ui/customer/login.tpl
@@ -23,25 +23,18 @@
                         <label>
                             {if $_c['registration_username'] == 'phone'}
                                 {Lang::T('Phone Number')}
-                            {elseif $_c['registration_username'] == 'email'}
-                                {Lang::T('Email')}
                             {else}
-                                {Lang::T('Usernames')}
+                                {Lang::T('Username or Email')}
                             {/if}
                         </label>
                         <div class="input-group">
                             {if $_c['registration_username'] == 'phone'}
-                                <span class="input-group-addon" id="basic-addon1"><i
-                                        class="glyphicon glyphicon-phone-alt"></i></span>
-                            {elseif $_c['registration_username'] == 'email'}
-                                <span class="input-group-addon" id="basic-addon1"><i
-                                        class="glyphicon glyphicon-envelope"></i></span>
+                                <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-phone-alt"></i></span>
                             {else}
-                                <span class="input-group-addon" id="basic-addon1"><i
-                                        class="glyphicon glyphicon-user"></i></span>
+                                <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-user"></i></span>
                             {/if}
                             <input type="text" class="form-control" name="username"
-                                placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
+                                placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{else}{Lang::T('Username or Email')}{/if}">
                         </div>
                     </div>
                     <div class="form-group">


### PR DESCRIPTION
## Summary
- Let customers log in with either username or email
- Permit admin login using username or email
- Update login forms to show username or email option

## Testing
- `php -l system/controllers/login.php`
- `php -l system/controllers/admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae9c28d4c8832abc0227a31a654290