### PR TITLE
Allow welcome package to use inactive plans

### DIFF
--- a/system/autoload/Package.php
+++ b/system/autoload/Package.php
@@ -72,7 +72,7 @@ class Package
         }
 
 
-        if (!$p['enabled']) {
+        if (!$p['enabled'] && $gateway != 'Welcome') {
             if (!isset($admin) || !isset($admin['id']) || empty($admin['id'])) {
                 r2(getUrl('home'), 'e', Lang::T('Plan Not found'));
             }

--- a/system/controllers/settings.php
+++ b/system/controllers/settings.php
@@ -145,7 +145,7 @@ switch ($action) {
 
         $r = ORM::for_table('tbl_routers')->find_many();
         $ui->assign('r', $r);
-        $plans = ORM::for_table('tbl_plans')->where('enabled', 1)->find_many();
+        $plans = ORM::for_table('tbl_plans')->find_many();
         $ui->assign('plans', $plans);
         if (function_exists("shell_exec")) {
             $which = stripos(php_uname('s'), "Win") === 0 ? 'where' : 'which';

--- a/ui/ui/admin/settings/app.tpl
+++ b/ui/ui/admin/settings/app.tpl
@@ -397,7 +397,7 @@
                         <select name="welcome_package_plan" class="form-control">
                             <option value="">{Lang::T('None')}</option>
                             {foreach $plans as $pl}
-                                <option value="{$pl['id']}" {if $_c['welcome_package_plan']==$pl['id']}selected="selected"{/if}>{$pl['name_plan']}</option>
+                                <option value="{$pl['id']}" {if $_c['welcome_package_plan']==$pl['id']}selected="selected"{/if}>{$pl['name_plan']}{if $pl['enabled'] == 0} ({Lang::T('Inactive')}){/if}</option>
                             {/foreach}
                         </select>
                     </div>


### PR DESCRIPTION
## Summary
- Include disabled plans when loading plan list for settings
- Mark inactive plans in the welcome package selection dropdown
- Permit welcome package recharges to use inactive plans

## Testing
- `php -l system/controllers/settings.php`
- `php -l system/autoload/Package.php`


------
https://chatgpt.com/codex/tasks/task_e_68aea935e170832aa1e952b1a7d27364