### PR TITLE
Handle missing cURL extension during Turnstile validation

### DIFF
--- a/system/controllers/login.php
+++ b/system/controllers/login.php
@@ -33,6 +33,10 @@ switch ($do) {
         $tsEnabled = (!empty($_c['turnstile_client_enabled']) && $_c['turnstile_client_enabled'] == '1');
         $secret = $_c['turnstile_secret_key'] ?? '';
         if ($secret === '' && defined('TURNSTILE_SECRET_KEY')) { $secret = TURNSTILE_SECRET_KEY; }
+        if ($tsEnabled && $secret !== '' && !extension_loaded('curl')) {
+            _msglog('e', Lang::T('cURL extension is missing'));
+            r2(getUrl('login'));
+        }
         if ($tsEnabled && $secret !== '') {
             $token = _post('cf-turnstile-response');
             if (empty($token)) {


### PR DESCRIPTION
## Summary
- prevent internal errors by checking for cURL extension before executing Turnstile verification

## Testing
- `php -l system/controllers/login.php`
- `php -m | grep curl`
- `php -r '$tsEnabled=true;$secret="abc";if ($tsEnabled && $secret !== "" && !extension_loaded("curl")){echo "curl missing\n";}else{echo "curl ok\n";}'`
- `php -n -r '$tsEnabled=true;$secret="abc";if ($tsEnabled && $secret !== "" && !extension_loaded("curl")){echo "curl missing\n";}else{echo "curl ok\n";}'` *(fails: cURL is built into the environment so could not test without it)*

------
https://chatgpt.com/codex/tasks/task_e_68aea8f56008832aa6185bd2fae9a6c5