### PR TITLE
Fix case-insensitive admin login query

### DIFF
--- a/system/controllers/admin.php
+++ b/system/controllers/admin.php
@@ -73,9 +73,9 @@ switch ($do) {
             }
         }   
         if ($username != '' and $password != '') {
+            $username = strtolower($username);
             $d = ORM::for_table('tbl_users')
-                ->where_raw('LOWER(username) = ?', $username)
-                ->or_where_raw('LOWER(email) = ?', $username)
+                ->where_raw('LOWER(username) = ? OR LOWER(email) = ?', [$username, $username])
                 ->find_one();
             if ($d) {
                 $d_pass = $d['password'];


### PR DESCRIPTION
## Summary
- ensure username is normalized before login lookup
- simplify admin login query to handle username/email matching case-insensitively

## Testing
- `php -l system/controllers/admin.php`
- `php /tmp/test_login.php`


------
https://chatgpt.com/codex/tasks/task_e_68aead73622c832ab14f290fbcbc5f89