### PR TITLE
feat: expand login username options

### DIFF
--- a/ui/ui/customer/login.tpl
+++ b/ui/ui/customer/login.tpl
@@ -23,18 +23,22 @@
                         <label>
                             {if $_c['registration_username'] == 'phone'}
                                 {Lang::T('Phone Number')}
+                            {elseif $_c['registration_username'] == 'email'}
+                                {Lang::T('Email')}
                             {else}
-                                {Lang::T('Username or Email')}
+                                {Lang::T('Usernames')}
                             {/if}
                         </label>
                         <div class="input-group">
                             {if $_c['registration_username'] == 'phone'}
                                 <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-phone-alt"></i></span>
+                            {elseif $_c['registration_username'] == 'email'}
+                                <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-envelope"></i></span>
                             {else}
                                 <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-user"></i></span>
                             {/if}
                             <input type="text" class="form-control" name="username"
-                                placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{else}{Lang::T('Username or Email')}{/if}">
+                                placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
                         </div>
                     </div>
                     <div class="form-group">


### PR DESCRIPTION
## Summary
- support phone, email, or username login identifiers with dynamic label, icon, and placeholder

## Testing
- `php /tmp/test_render.php`

------
https://chatgpt.com/codex/tasks/task_e_68aeb79cb388832a97f27d0a248fd326