### PR TITLE
Streamline username and contact fields in registration

### DIFF
--- a/ui/ui/customer/reg-login-custom-moon.tpl
+++ b/ui/ui/customer/reg-login-custom-moon.tpl
@@ -356,30 +356,48 @@
                                 <input type="hidden" name="csrf_token" value="{$csrf_token}">
 
                                 <!-- Basic Information (Initially Visible) -->
-                                <div id="basicFields">
-                                    <div class="form-group">
-                                        <input type="text" name="username"
-                                            placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
-                                    </div>
-                                    {if $_c['photo_register'] == 'yes'}
-                                    <div class="form-group">
-                                        <input type="file" required id="photo" name="photo"
-                                            accept="image/*">
-                                    </div>
-                                    {/if}
+                                  <div id="basicFields">
+                                      {if $_c['registration_username'] != 'phone'}
+                                      <div class="form-group">
+                                          <input type="text" id="username" name="username"
+                                              placeholder="{if $_c['registration_username'] == 'email'}{Lang::T('Email')}{elseif $_c['registration_username'] == 'username'}{Lang::T('Usernames')}{else}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{/if}">
+                                      </div>
+                                      {else}
+                                      <input type="hidden" id="username" name="username">
+                                      {/if}
+                                      {if $_c['photo_register'] == 'yes'}
+                                      <div class="form-group">
+                                          <input type="file" required id="photo" name="photo"
+                                              accept="image/*">
+                                      </div>
+                                      {/if}
                                     <div class="form-group">
                                         <input type="text" name="fullname" placeholder="{Lang::T('Full Name')}"
                                         {if $_c['man_fields_fname'] neq 'no'}required{/if} >
                                     </div>
-                                    <div class="form-group">
-                                        <input type="email" name="email" placeholder="{Lang::T('Email Address')}"
-                                        {if $_c['man_fields_email'] neq 'no'}required{/if}>
-                                    </div>
-                                    <div class="form-group">
-                                        <button type="button" onclick="toggleFields()" class="submit-btn">
-                                            {Lang::T('Next Step')}
-                                        </button>
-                                    </div>
+                                      {if $_c['registration_username'] != 'email'}
+                                      <div class="form-group">
+                                          <input type="email" id="email" name="email" placeholder="{Lang::T('Email Address')}"
+                                          {if $_c['man_fields_email'] neq 'no'}required{/if}>
+                                      </div>
+                                      {else}
+                                      <input type="hidden" id="email" name="email">
+                                      <script>
+                                      document.addEventListener('DOMContentLoaded', function() {
+                                          var u = document.getElementById('username');
+                                          var e = document.getElementById('email');
+                                          if (u && e) {
+                                              e.value = u.value;
+                                              u.addEventListener('input', function() { e.value = u.value; });
+                                          }
+                                      });
+                                      </script>
+                                      {/if}
+                                      <div class="form-group">
+                                          <button type="button" onclick="toggleFields()" class="submit-btn">
+                                              {Lang::T('Next Step')}
+                                          </button>
+                                      </div>
                                 </div>
 
                                 <!-- Password Fields (Initially Hidden) -->

--- a/ui/ui/customer/register-otp.tpl
+++ b/ui/ui/customer/register-otp.tpl
@@ -18,26 +18,11 @@
                     <div class="form-container">
                         <!-- Phone Number Field -->
                         <div class="form-group">
-                            <label>
-                                {if $_c['registration_username'] == 'phone'}
-                                    {Lang::T('Phone Number')}
-                                {elseif $_c['registration_username'] == 'email'}
-                                    {Lang::T('Email')}
-                                {else}
-                                    {Lang::T('Usernames')}
-                                {/if}
-                            </label>
+                            <label>{Lang::T('Phone Number')}</label>
                             <div class="input-group">
-                                {if $_c['registration_username'] == 'phone'}
-                                    <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-phone-alt"></i></span>
-                                {elseif $_c['registration_username'] == 'email'}
-                                    <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-envelope"></i></span>
-                                {else}
-                                    <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-user"></i></span>
-                                {/if}
-                                <input type="text" class="form-control" name="phone_number" value="{$phone_number}"
-                                    readonly
-                                    placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
+                                <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-phone-alt"></i></span>
+                                <input type="text" class="form-control" name="phone_number" value="{$phone_number}" readonly
+                                    placeholder="{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}">
                             </div>
                         </div>
                         <div class="form-group">
@@ -77,11 +62,32 @@
                 <div class="panel-body">
                     <div class="form-container">
                         <!-- Username Field -->
+                        {if $_c['registration_username'] == 'username'}
                         <div class="form-group">
                             <label>{Lang::T('Usernames')}</label>
                             <input type="text" required class="form-control" id="username" name="username"
                                 placeholder="{Lang::T('Choose a Usernames')}">
                         </div>
+                        {else}
+                        <input type="hidden" id="username" name="username">
+                        {/if}
+                        {if $_c['registration_username'] != 'username'}
+                        <script>
+                        document.addEventListener('DOMContentLoaded', function() {
+                            var u = document.getElementById('username');
+                            {if $_c['registration_username'] == 'phone'}
+                            var p = document.getElementsByName('phone_number')[0];
+                            if (u && p) { u.value = p.value; }
+                            {elseif $_c['registration_username'] == 'email'}
+                            var e = document.getElementById('email');
+                            if (u && e) {
+                                u.value = e.value;
+                                e.addEventListener('input', function(){ u.value = e.value; });
+                            }
+                            {/if}
+                        });
+                        </script>
+                        {/if}
                         <!-- Password Fields -->
                         <div class="form-group">
                             <label>{Lang::T('Password')}</label>

--- a/ui/ui/customer/register-rotp.tpl
+++ b/ui/ui/customer/register-rotp.tpl
@@ -19,25 +19,11 @@
                 <div class="panel-heading">1. {Lang::T('Register as Member')}</div>
                 <div class="panel-body">
                     <div class="form-group">
-                        <label>
-                            {if $_c['registration_username'] == 'phone'}
-                                {Lang::T('Phone Number')}
-                            {elseif $_c['registration_username'] == 'email'}
-                                {Lang::T('Email')}
-                            {else}
-                                {Lang::T('Usernames')}
-                            {/if}
-                        </label>
+                        <label>{Lang::T('Phone Number')}</label>
                         <div class="input-group">
-                            {if $_c['registration_username'] == 'phone'}
-                                <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-phone-alt"></i></span>
-                            {elseif $_c['registration_username'] == 'email'}
-                                <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-envelope"></i></span>
-                            {else}
-                                <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-user"></i></span>
-                            {/if}
+                            <span class="input-group-addon" id="basic-addon1"><i class="glyphicon glyphicon-phone-alt"></i></span>
                             <input type="text" class="form-control" name="phone_number"
-                                placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}"
+                                placeholder="{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}"
                                 inputmode="numeric" pattern="[0-9]*">
                         </div>
                     </div>

--- a/ui/ui/customer/register.tpl
+++ b/ui/ui/customer/register.tpl
@@ -16,31 +16,35 @@
                 <div class="panel-heading">1. {Lang::T('Register as Member')}</div>
                 <div class="panel-body">
                     <div class="form-container">
+                        {if $_c['registration_username'] != 'phone'}
                         <div class="form-group">
                             <label>
-                                {if $_c['registration_username'] == 'phone'}
-                                    {Lang::T('Phone Number')}
-                                {elseif $_c['registration_username'] == 'email'}
+                                {if $_c['registration_username'] == 'email'}
                                     {Lang::T('Email')}
-                                {else}
+                                {elseif $_c['registration_username'] == 'username'}
                                     {Lang::T('Usernames')}
+                                {else}
+                                    {Lang::T('Phone Number')}
                                 {/if}
                             </label>
                             <div class="input-group">
-                                {if $_c['registration_username'] == 'phone'}
-                                    <span class="input-group-addon" id="basic-addon1"><i
-                                            class="glyphicon glyphicon-phone-alt"></i></span>
-                                {elseif $_c['registration_username'] == 'email'}
+                                {if $_c['registration_username'] == 'email'}
                                     <span class="input-group-addon" id="basic-addon1"><i
                                             class="glyphicon glyphicon-envelope"></i></span>
-                                {else}
+                                {elseif $_c['registration_username'] == 'username'}
                                     <span class="input-group-addon" id="basic-addon1"><i
                                             class="glyphicon glyphicon-user"></i></span>
+                                {else}
+                                    <span class="input-group-addon" id="basic-addon1"><i
+                                            class="glyphicon glyphicon-phone-alt"></i></span>
                                 {/if}
-                                <input type="text" class="form-control" name="username"
-                                    placeholder="{if $_c['registration_username'] == 'phone'}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{elseif $_c['registration_username'] == 'email'}{Lang::T('Email')}{else}{Lang::T('Usernames')}{/if}">
+                                <input type="text" class="form-control" id="username" name="username"
+                                    placeholder="{if $_c['registration_username'] == 'email'}{Lang::T('Email')}{elseif $_c['registration_username'] == 'username'}{Lang::T('Usernames')}{else}{if $_c['country_code_phone'] != ''}{$_c['country_code_phone']} {/if}{Lang::T('Phone Number')}{/if}">
                             </div>
                         </div>
+                        {else}
+                        <input type="hidden" id="username" name="username">
+                        {/if}
                         {if $_c['photo_register'] == 'yes'}
                             <div class="form-group">
                                 <label>{Lang::T('Photo')}</label>
@@ -52,11 +56,25 @@
                             <input type="text" {if $_c['man_fields_fname'] neq 'no'}required{/if} class="form-control"
                                 id="fullname" value="{$fullname}" name="fullname">
                         </div>
+                        {if $_c['registration_username'] != 'email'}
                         <div class="form-group">
                             <label>{Lang::T('Email')}</label>
                             <input type="text" {if $_c['man_fields_email'] neq 'no'}required{/if} class="form-control"
                                 id="email" placeholder="xxxxxxx@xxxx.xx" value="{$email}" name="email">
                         </div>
+                        {else}
+                        <input type="hidden" id="email" name="email">
+                        <script>
+                        document.addEventListener('DOMContentLoaded', function() {
+                            var u = document.getElementById('username');
+                            var e = document.getElementById('email');
+                            if (u && e) {
+                                e.value = u.value;
+                                u.addEventListener('input', function() { e.value = u.value; });
+                            }
+                        });
+                        </script>
+                        {/if}
                         <div class="form-group">
                             <label>{Lang::T('Home Address')}</label>
                             <input type="text" {if $_c['man_fields_address'] neq 'no'}required{/if} name="address"


### PR DESCRIPTION
## Summary
- Always display OTP request fields as plain phone numbers
- Show username input only when needed and auto-fill from phone or email elsewhere
- Treat primary email as login identifier and hide duplicate contact email

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aebc0513b4832aa8947e538e173138