### PR TITLE
Sync username and email for email-based registration

### DIFF
--- a/system/controllers/register.php
+++ b/system/controllers/register.php
@@ -26,6 +26,9 @@ switch ($do) {
             $username = alphanumeric(_post('username'), "+_.@-");
         }
         $email = _post('email');
+        if ($_c['registration_username'] === 'email') {
+            $email = $username;
+        }
         $fullname = _post('fullname');
         $password = _post('password');
         $cpassword = _post('cpassword');
@@ -117,7 +120,11 @@ switch ($do) {
             $d->password = $password;
             $d->fullname = $fullname;
             $d->address = $address;
-            $d->email = $email;
+            if ($_c['registration_username'] === 'email') {
+                $d->email = $d->username;
+            } else {
+                $d->email = $email;
+            }
             $d->phonenumber = $formatted;
             if ($d->save()) {
                 $user = $d->id();

--- a/ui/ui/customer/register-otp.tpl
+++ b/ui/ui/customer/register-otp.tpl
@@ -41,11 +41,15 @@
                             <input type="text" {if $_c['man_fields_fname'] neq 'no'}required{/if} class="form-control"
                                 id="fullname" value="{$fullname}" name="fullname">
                         </div>
+                        {if $_c['registration_username'] != 'email'}
                         <div class="form-group">
                             <label>{Lang::T('Email')}</label>
                             <input type="text" class="form-control" {if $_c['man_fields_email'] neq 'no'}required{/if}
                                 placeholder="xxxxxx@xxx.xx" id="email" value="{$email}" name="email">
                         </div>
+                        {else}
+                        <input type="hidden" id="email" name="email" value="{$email}">
+                        {/if}
                         <div class="form-group">
                             <label>{Lang::T('Home Address')}</label>
                             <input type="text" name="address" {if $_c['man_fields_address'] neq 'no'}required{/if}
@@ -66,25 +70,31 @@
                         <div class="form-group">
                             <label>{Lang::T('Usernames')}</label>
                             <input type="text" required class="form-control" id="username" name="username"
-                                placeholder="{Lang::T('Choose a Usernames')}">
+                                placeholder="{Lang::T('Choose a Usernames')}" value="{$username}">
                         </div>
-                        {else}
-                        <input type="hidden" id="username" name="username">
-                        {/if}
-                        {if $_c['registration_username'] != 'username'}
+                        {elseif $_c['registration_username'] == 'email'}
+                        <div class="form-group">
+                            <label>{Lang::T('Email')}</label>
+                            <input type="text" required class="form-control" id="username" name="username"
+                                placeholder="xxxxxx@xxx.xx" value="{$username}">
+                        </div>
                         <script>
                         document.addEventListener('DOMContentLoaded', function() {
                             var u = document.getElementById('username');
-                            {if $_c['registration_username'] == 'phone'}
-                            var p = document.getElementsByName('phone_number')[0];
-                            if (u && p) { u.value = p.value; }
-                            {elseif $_c['registration_username'] == 'email'}
                             var e = document.getElementById('email');
                             if (u && e) {
-                                u.value = e.value;
-                                e.addEventListener('input', function(){ u.value = e.value; });
+                                e.value = u.value;
+                                u.addEventListener('input', function(){ e.value = u.value; });
                             }
-                            {/if}
+                        });
+                        </script>
+                        {else}
+                        <input type="hidden" id="username" name="username">
+                        <script>
+                        document.addEventListener('DOMContentLoaded', function() {
+                            var u = document.getElementById('username');
+                            var p = document.getElementsByName('phone_number')[0];
+                            if (u && p) { u.value = p.value; }
                         });
                         </script>
                         {/if}

--- a/ui/ui/customer/register.tpl
+++ b/ui/ui/customer/register.tpl
@@ -63,7 +63,7 @@
                                 id="email" placeholder="xxxxxxx@xxxx.xx" value="{$email}" name="email">
                         </div>
                         {else}
-                        <input type="hidden" id="email" name="email">
+                        <input type="hidden" id="email" name="email" value="{$username}">
                         <script>
                         document.addEventListener('DOMContentLoaded', function() {
                             var u = document.getElementById('username');


### PR DESCRIPTION
## Summary
- Auto-fill hidden email with login when registering by email
- Remove redundant email field in OTP flow and sync it with login
- Store login email in both username and email columns during email-only registration

## Testing
- `php -l system/controllers/register.php`


------
https://chatgpt.com/codex/tasks/task_e_68aebf49f7a8832ab02a1bab6ec1df5b